### PR TITLE
Make log file names unique across multiple application launches

### DIFF
--- a/FBControlCore/Diagnostics/FBASLParser.m
+++ b/FBControlCore/Diagnostics/FBASLParser.m
@@ -88,9 +88,10 @@ static BOOL WriteOutputToFilePath(const char *filePath, asl_object_t aslFile, pi
 
 - (FBDiagnostic *)diagnosticForProcessInfo:(FBProcessInfo *)processInfo logBuilder:(FBDiagnosticBuilder *)logBuilder
 {
-  return [[[[logBuilder
+  return [[[[[logBuilder
     updateShortName:processInfo.processName]
     updateFileType:@"log"]
+    updateStorageDirectoryByAppendingPathComponent:NSUUID.UUID.UUIDString]
     updatePathFromBlock:^ BOOL (NSString *outputPath) {
       return WriteOutputToFilePath(outputPath.UTF8String, self.asl, processInfo.processIdentifier);
     }]

--- a/FBControlCore/Diagnostics/FBDiagnostic.h
+++ b/FBControlCore/Diagnostics/FBDiagnostic.h
@@ -163,6 +163,14 @@ typedef NSString *FBDiagnosticName NS_EXTENSIBLE_STRING_ENUM;
 - (instancetype)updateStorageDirectory:(NSString *)storageDirectory;
 
 /**
+ Appends given path component to the current `storageDirectory` of the underlying `FBDiagnostic`.
+
+ @param pathComponent the path component that should be appended to the current storageDirectory.
+ @return the reciever, for chaining.
+ */
+- (instancetype)updateStorageDirectoryByAppendingPathComponent:(NSString *)pathComponent;
+
+/**
  Updates the `destination` of the underlying `FBDiagnostic`.
 
  @param destination the Destination to update with.

--- a/FBControlCore/Diagnostics/FBDiagnostic.m
+++ b/FBControlCore/Diagnostics/FBDiagnostic.m
@@ -633,7 +633,7 @@
 - (BOOL)hasLogContent
 {
   NSDictionary *attributes = [NSFileManager.defaultManager attributesOfItemAtPath:self.backingFilePath error:nil];
-  return attributes[NSFileSize] && [attributes[NSFileSize] unsignedLongLongValue] > 0;
+  return attributes[NSFileType] == NSFileTypeRegular && attributes[NSFileSize] && [attributes[NSFileSize] unsignedLongLongValue] > 0;
 }
 
 - (BOOL)writeOutToFilePath:(NSString *)path error:(NSError **)error

--- a/FBControlCore/Diagnostics/FBDiagnostic.m
+++ b/FBControlCore/Diagnostics/FBDiagnostic.m
@@ -936,6 +936,13 @@
   return self;
 }
 
+- (instancetype)updateStorageDirectoryByAppendingPathComponent:(NSString *)pathComponent
+{
+  NSAssert(self.diagnostic.storageDirectory, @"storageDirectory may not be nil when appending path component");
+  self.diagnostic.storageDirectory = [self.diagnostic.storageDirectory stringByAppendingPathComponent:pathComponent];
+  return self;
+}
+
 - (instancetype)updateDestination:(NSString *)destination
 {
   self.diagnostic.destination = destination;

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		05046C021D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.m in Sources */ = {isa = PBXBuildFile; fileRef = 05046C001D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.m */; };
 		051E96FC1E5544A200301DFF /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		05471D691D5991AF00232CB2 /* junitResult0.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05471D681D5991AF00232CB2 /* junitResult0.xml */; };
+		058663DD1E59AE080073699C /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		0593EA101E371E5800EBD7CB /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		05AC8AFB1D587A8B008B435E /* FBTestManagerTestReporterBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 05AC8AF91D587A8B008B435E /* FBTestManagerTestReporterBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05AC8AFC1D587A8B008B435E /* FBTestManagerTestReporterBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 05AC8AFA1D587A8B008B435E /* FBTestManagerTestReporterBase.m */; };
@@ -3431,6 +3432,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				058663DD1E59AE080073699C /* libShimulator.dylib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		05046C011D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.h in Headers */ = {isa = PBXBuildFile; fileRef = 05046BFF1D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05046C021D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.m in Sources */ = {isa = PBXBuildFile; fileRef = 05046C001D48B8BA00295EE1 /* FBTestManagerTestReporterComposite.m */; };
+		051E96FC1E5544A200301DFF /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		05471D691D5991AF00232CB2 /* junitResult0.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05471D681D5991AF00232CB2 /* junitResult0.xml */; };
 		0593EA101E371E5800EBD7CB /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		05AC8AFB1D587A8B008B435E /* FBTestManagerTestReporterBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 05AC8AF91D587A8B008B435E /* FBTestManagerTestReporterBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -3402,6 +3403,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				051E96FC1E5544A200301DFF /* libShimulator.dylib in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
+++ b/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
@@ -146,9 +146,8 @@ NSString *const FBDiagnosticNameScreenshot = @"screenshot";
 - (FBDiagnostic *)stdOut:(FBProcessLaunchConfiguration *)configuration
 {
   NSString *name = [NSString stringWithFormat:@"%@_out", configuration.identifiableName];
-  return [[[[[[self.baseLogBuilder
+  return [[[[[self.baseLogBuilder
     updateStorageDirectory:[self stdOutErrContainersPath]]
-    updateStorageDirectoryByAppendingPathComponent:NSUUID.UUID.UUIDString]
     updateShortName:name]
     updateFileType:@"txt"]
     updatePathFromDefaultLocation]
@@ -158,9 +157,8 @@ NSString *const FBDiagnosticNameScreenshot = @"screenshot";
 - (FBDiagnostic *)stdErr:(FBProcessLaunchConfiguration *)configuration
 {
   NSString *name = [NSString stringWithFormat:@"%@_err", configuration.identifiableName];
-  return [[[[[[self.baseLogBuilder
+  return [[[[[self.baseLogBuilder
     updateStorageDirectory:[self stdOutErrContainersPath]]
-    updateStorageDirectoryByAppendingPathComponent:NSUUID.UUID.UUIDString]
     updateShortName:name]
     updateFileType:@"txt"]
     updatePathFromDefaultLocation]

--- a/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
+++ b/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
@@ -169,7 +169,11 @@ NSString *const FBDiagnosticNameScreenshot = @"screenshot";
 
 - (NSArray<FBDiagnostic *> *)stdOutErrDiagnostics
 {
-  return [FBSimulatorDiagnostics diagnosticsForSubpathsOf:self.stdOutErrContainersPath];
+  NSMutableArray *stdOutErrDiagnostics = [NSMutableArray array];
+  for (NSString *path in [FBFileFinder contentsOfDirectoryWithBasePath:self.stdOutErrContainersPath]) {
+    [stdOutErrDiagnostics addObjectsFromArray:[FBSimulatorDiagnostics diagnosticsForSubpathsOf:path]];
+  }
+  return [stdOutErrDiagnostics copy];
 }
 
 - (NSDictionary<FBProcessInfo *, FBDiagnostic *> *)launchedProcessLogs

--- a/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
+++ b/FBSimulatorControl/Diagnostics/FBSimulatorDiagnostics.m
@@ -146,8 +146,9 @@ NSString *const FBDiagnosticNameScreenshot = @"screenshot";
 - (FBDiagnostic *)stdOut:(FBProcessLaunchConfiguration *)configuration
 {
   NSString *name = [NSString stringWithFormat:@"%@_out", configuration.identifiableName];
-  return [[[[[self.baseLogBuilder
+  return [[[[[[self.baseLogBuilder
     updateStorageDirectory:[self stdOutErrContainersPath]]
+    updateStorageDirectoryByAppendingPathComponent:NSUUID.UUID.UUIDString]
     updateShortName:name]
     updateFileType:@"txt"]
     updatePathFromDefaultLocation]
@@ -157,8 +158,9 @@ NSString *const FBDiagnosticNameScreenshot = @"screenshot";
 - (FBDiagnostic *)stdErr:(FBProcessLaunchConfiguration *)configuration
 {
   NSString *name = [NSString stringWithFormat:@"%@_err", configuration.identifiableName];
-  return [[[[[self.baseLogBuilder
+  return [[[[[[self.baseLogBuilder
     updateStorageDirectory:[self stdOutErrContainersPath]]
+    updateStorageDirectoryByAppendingPathComponent:NSUUID.UUID.UUIDString]
     updateShortName:name]
     updateFileType:@"txt"]
     updatePathFromDefaultLocation]

--- a/FBSimulatorControl/Strategies/FBApplicationLaunchStrategy.m
+++ b/FBSimulatorControl/Strategies/FBApplicationLaunchStrategy.m
@@ -302,7 +302,7 @@
   for (NSUInteger index = 0; index < referencePath.pathComponents.count; index++) {
     translatedPath = [translatedPath stringByAppendingPathComponent:@".."];
   }
-  return [translatedPath stringByAppendingPathComponent:absolutePath];
+  return [translatedPath stringByAppendingPathComponent:[absolutePath stringByAddingPercentEscapesUsingEncoding:NSUTF8StringEncoding]];
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -91,6 +91,30 @@
   }];
 }
 
+- (void)testLaunchedApplicationLogsWithDefaultOutputToFile
+{
+  if (FBSimulatorControlTestCase.isRunningOnTravis) {
+    return;
+  }
+
+  FBSimulator *simulator = [self assertObtainsBootedSimulator];
+  FBProcessOutputConfiguration *output = [FBProcessOutputConfiguration defaultOutputToFile];
+  FBApplicationLaunchConfiguration *appLaunch = [self.tableSearchAppLaunch.injectingShimulator withOutput:output];
+  [self assertInteractionSuccessful:[[simulator.interact installApplication:self.tableSearchApplication] launchApplication:appLaunch]];
+
+  [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
+    return [[simulator.simulatorDiagnostics.launchedProcessLogs.allValues firstObject] asString];
+  }];
+
+  [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
+    NSString *haystack = @"";
+    for (FBDiagnostic *diagnostic in simulator.simulatorDiagnostics.stdOutErrDiagnostics) {
+        haystack = [haystack stringByAppendingString:[diagnostic asString]];
+    }
+    return haystack.length ? haystack : nil;
+  }];
+}
+
 - (void)testLaunchedApplicationLogsWithCustomLogFilePath
 {
   if (FBSimulatorControlTestCase.isRunningOnTravis) {

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -74,11 +74,7 @@
 
 - (void)testLaunchedApplicationLogs
 {
-  if (FBSimulatorControlTestCase.isRunningOnTravis) {
-    return;
-  }
-
-  FBSimulator *simulator = [self assertObtainsBootedSimulatorWithInstalledApplication:self.tableSearchApplication];
+  FBSimulator *simulator = [self assertObtainsBootedSimulator];
   FBApplicationLaunchConfiguration *appLaunch = self.tableSearchAppLaunch.injectingShimulator;
 
   NSError *error = nil;
@@ -93,14 +89,14 @@
 
 - (void)testLaunchedApplicationLogsWithDefaultOutputToFile
 {
-  if (FBSimulatorControlTestCase.isRunningOnTravis) {
-    return;
-  }
-
   FBSimulator *simulator = [self assertObtainsBootedSimulator];
   FBProcessOutputConfiguration *output = [FBProcessOutputConfiguration defaultOutputToFile];
   FBApplicationLaunchConfiguration *appLaunch = [self.tableSearchAppLaunch.injectingShimulator withOutput:output];
-  [self assertInteractionSuccessful:[[simulator.interact installApplication:self.tableSearchApplication] launchApplication:appLaunch]];
+
+  NSError *error = nil;
+  BOOL success = [simulator launchApplication:appLaunch error:&error];
+  XCTAssertNil(error);
+  XCTAssertTrue(success);
 
   [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
     return [[simulator.simulatorDiagnostics.launchedProcessLogs.allValues firstObject] asString];
@@ -117,10 +113,6 @@
 
 - (void)testLaunchedApplicationLogsWithCustomLogFilePath
 {
-  if (FBSimulatorControlTestCase.isRunningOnTravis) {
-    return;
-  }
-
   NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
   NSString *stdErrPath = [[path stringByAppendingPathComponent:@"Some Thing With Space"] stringByAppendingPathComponent:@"stderr.log"];
   NSString *stdOutPath = [[path stringByAppendingPathComponent:@"Some Thing With Space"] stringByAppendingPathComponent:@"stdout.log"];

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -182,13 +182,23 @@
   for (int i = 0; i < 3; i++) {
     FBDiagnostic *diagnostic = nil;
     [appLaunch createStdErrDiagnosticForSimulator:simulator diagnosticOut:&diagnostic error:nil];
+    [@"stderr content" writeToFile:diagnostic.asPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
     [stdErrDiagnostics addObject:diagnostic];
     [appLaunch createStdOutDiagnosticForSimulator:simulator diagnosticOut:&diagnostic error:nil];
+    [@"stdout content" writeToFile:diagnostic.asPath atomically:YES encoding:NSUTF8StringEncoding error:nil];
     [stdOutDiagnostics addObject:diagnostic];
   }
 
   XCTAssertEqual(stdErrDiagnostics.count, 3u);
   XCTAssertEqual(stdOutDiagnostics.count, 3u);
+  XCTAssertEqual(simulator.simulatorDiagnostics.stdOutErrDiagnostics.count, 6u);
+
+  NSFileManager *fileManager = [NSFileManager defaultManager];
+  for (FBDiagnostic *diagnostic in simulator.simulatorDiagnostics.stdOutErrDiagnostics) {
+    BOOL isDirectory;
+    XCTAssertTrue([fileManager fileExistsAtPath:diagnostic.asPath isDirectory:&isDirectory]);
+    XCTAssertFalse(isDirectory);
+  }
 }
 
 @end

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -170,4 +170,25 @@
   XCTAssertTrue([fileManager fileExistsAtPath:stdOutDiagnostic.asPath]);
 }
 
+- (void)testCreateStdErrDiagnosticForSimulatorMultipleTimesCreatesUniqueLogFiles
+{
+  FBSimulator *simulator = [self assertObtainsSimulator];
+  FBProcessOutputConfiguration *output = [FBProcessOutputConfiguration defaultOutputToFile];
+  FBApplicationLaunchConfiguration *appLaunch = [self.tableSearchAppLaunch withOutput:output];
+
+  NSMutableSet *stdErrDiagnostics = [NSMutableSet set];
+  NSMutableSet *stdOutDiagnostics = [NSMutableSet set];
+
+  for (int i = 0; i < 3; i++) {
+    FBDiagnostic *diagnostic = nil;
+    [appLaunch createStdErrDiagnosticForSimulator:simulator diagnosticOut:&diagnostic error:nil];
+    [stdErrDiagnostics addObject:diagnostic];
+    [appLaunch createStdOutDiagnosticForSimulator:simulator diagnosticOut:&diagnostic error:nil];
+    [stdOutDiagnostics addObject:diagnostic];
+  }
+
+  XCTAssertEqual(stdErrDiagnostics.count, 3u);
+  XCTAssertEqual(stdOutDiagnostics.count, 3u);
+}
+
 @end

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -122,8 +122,8 @@
   }
 
   NSString *path = [NSTemporaryDirectory() stringByAppendingPathComponent:NSUUID.UUID.UUIDString];
-  NSString *stdErrPath = [path stringByAppendingPathComponent:@"stderr.log"];
-  NSString *stdOutPath = [path stringByAppendingPathComponent:@"stdout.log"];
+  NSString *stdErrPath = [[path stringByAppendingPathComponent:@"Some Thing With Space"] stringByAppendingPathComponent:@"stderr.log"];
+  NSString *stdOutPath = [[path stringByAppendingPathComponent:@"Some Thing With Space"] stringByAppendingPathComponent:@"stdout.log"];
 
   FBProcessOutputConfiguration *output = [FBProcessOutputConfiguration configurationWithStdOut:stdOutPath stdErr:stdErrPath error:nil];
   FBSimulator *simulator = [self assertObtainsBootedSimulatorWithInstalledApplication:self.tableSearchApplication];

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -117,11 +117,8 @@
   [self assertFindsNeedle:@"Shimulator" fromHaystackBlock:^ NSString * {
     NSString *stdErrContent = [NSString stringWithContentsOfFile:stdErrPath encoding:NSUTF8StringEncoding error:nil] ?: @"";
     NSString *stdOutContent = [NSString stringWithContentsOfFile:stdOutPath encoding:NSUTF8StringEncoding error:nil] ?: @"";
-    NSString *combinedContent = [stdErrContent stringByAppendingString:stdOutContent];
-    if (!combinedContent.length) {
-      return nil;
-    }
-    return combinedContent;
+    NSString *haystack = [stdErrContent stringByAppendingString:stdOutContent];
+    return haystack.length ? haystack : nil;
   }];
 }
 

--- a/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
+++ b/FBSimulatorControlTests/Tests/Integration/FBSimulatorDiagnosticsTests.m
@@ -74,7 +74,7 @@
 
 - (void)testLaunchedApplicationLogs
 {
-  FBSimulator *simulator = [self assertObtainsBootedSimulator];
+  FBSimulator *simulator = [self assertObtainsBootedSimulatorWithInstalledApplication:self.tableSearchApplication];
   FBApplicationLaunchConfiguration *appLaunch = self.tableSearchAppLaunch.injectingShimulator;
 
   NSError *error = nil;
@@ -89,7 +89,7 @@
 
 - (void)testLaunchedApplicationLogsWithDefaultOutputToFile
 {
-  FBSimulator *simulator = [self assertObtainsBootedSimulator];
+  FBSimulator *simulator = [self assertObtainsBootedSimulatorWithInstalledApplication:self.tableSearchApplication];
   FBProcessOutputConfiguration *output = [FBProcessOutputConfiguration defaultOutputToFile];
   FBApplicationLaunchConfiguration *appLaunch = [self.tableSearchAppLaunch.injectingShimulator withOutput:output];
 


### PR DESCRIPTION
When launching the same application multiple times, the log file gets overwritten multiple times, because the name is not unique.