### PR TITLE
Force dot decimalseparator on NSNumberformatter

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -28,7 +28,9 @@ extension Parser {
     let desc = PrimitiveDesc(name: "double",
                              desc: "Double-precision floating point number.")
     return Parser<Double>.single(desc) { token in
-      guard let double = NumberFormatter().number(from: token)?.doubleValue else {
+      let numberFormatter = NumberFormatter()
+      numberFormatter.decimalSeparator = "."
+      guard let double = numberFormatter.number(from: token)?.doubleValue else {
         throw ParseError.couldNotInterpret("Double", token)
       }
       return double


### PR DESCRIPTION
I was was wasting some time over the following command not working:
```
$ fbsimctl --state=booted set_location "37.77493" "-122.419416"
```

As it turns out my Mac's default locale has a `,` decimal separator, which also applies to reading a number with `NSNumberFormatter`. For a commandline utility this doesn't seem very useful, so force a `.` (dot) decimal separator for values parsed into doubles.