### PR TITLE
Return correct registration port value in Future-based API

### DIFF
--- a/FBSimulatorControl/HID/FBSimulatorHID.m
+++ b/FBSimulatorControl/HID/FBSimulatorHID.m
@@ -137,7 +137,7 @@ static const char *SimulatorHIDClientClassName = "SimulatorKit.SimDeviceLegacyHI
         causedBy:innerError]
         failFuture];
     }
-    return [FBFuture futureWithResult:@(result)];
+    return [FBFuture futureWithResult:@(registrationPort)];
   }];
 }
 


### PR DESCRIPTION
Hi! Most of the HID implementation is still beyond me, but as I work through trying to use it I noticed what looked like a small error made when this code was rewritten to use FBFutures in 21735b26b394d05f9b2da3c5d4f3235450cc5126.