### PR TITLE
Add Alternative Diagnostic Report Path for Simulators

### DIFF
--- a/FBControlCore/Diagnostics/FBCrashLogInfo.m
+++ b/FBControlCore/Diagnostics/FBCrashLogInfo.m
@@ -189,7 +189,13 @@
 
 + (NSString *)diagnosticReportsPath
 {
-  return [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Logs/DiagnosticReports"];
+  NSString *userReportsPath = [NSHomeDirectory() stringByAppendingPathComponent:@"Library/Logs/DiagnosticReports"];
+  BOOL userReportsPathExists = [[NSFileManager defaultManager] fileExistsAtPath:userReportsPath];
+  if (userReportsPathExists) {
+    return userReportsPath;
+  }
+  // diagnostic reports for root
+  return @"/Library/Logs/DiagnosticReports";
 }
 
 #pragma mark Private


### PR DESCRIPTION
Summary: The default user's Diagnostic Report Path does not exist when a root user is used.

Reviewed By: lawrencelomax

Differential Revision: D8346297
