### PR TITLE
fix for recording video in simulators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ output/
 
 # Files copied from Xcode
 Fixtures/Source/FBTestRunnerApp/Frameworks
+out

--- a/FBDeviceControl/Video/FBDeviceBitmapStream.m
+++ b/FBDeviceControl/Video/FBDeviceBitmapStream.m
@@ -195,15 +195,53 @@ static NSDictionary<NSString *, id> *FBBitmapStreamPixelBufferAttributesFromPixe
 - (void)consumeSampleBuffer:(CMSampleBufferRef)sampleBuffer
 {
   CVImageBufferRef pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer);
-  CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+//  CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+//
+//  void *baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer);
+//  size_t size = CVPixelBufferGetDataSize(pixelBuffer);
+//  NSData *data = [NSData dataWithBytesNoCopy:baseAddress length:size freeWhenDone:NO];
+//  [self.consumer consumeData:data];
+//
+//  CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 
-  void *baseAddress = CVPixelBufferGetBaseAddress(pixelBuffer);
-  size_t size = CVPixelBufferGetDataSize(pixelBuffer);
-  NSData *data = [NSData dataWithBytesNoCopy:baseAddress length:size freeWhenDone:NO];
-  [self.consumer consumeData:data];
-
-  CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-
+    size_t width = CVPixelBufferGetWidth(pixelBuffer);
+    size_t height = CVPixelBufferGetHeight(pixelBuffer);
+    size_t bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    
+    CVPixelBufferLockBaseAddress(pixelBuffer, 0);
+    GLubyte *sourceImageBytes = CVPixelBufferGetBaseAddress(pixelBuffer);
+    CGDataProviderRef dataProvider = CGDataProviderCreateWithData(NULL, sourceImageBytes, (unsigned long)(bytesPerRow * height), NULL);
+    CGColorSpaceRef genericRGBColorspace = CGColorSpaceCreateDeviceRGB();
+    CGImageRef cgImageFromBytes = CGImageCreate(width, height, 8, 32, bytesPerRow, genericRGBColorspace, kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst, dataProvider, NULL, NO, kCGRenderingIntentDefault);
+    
+    size_t finalWidth = width;
+    size_t finalHeight = height;
+    
+    GLubyte *imageData = (GLubyte *) calloc(1, finalWidth * finalHeight * 4);
+    
+    CGContextRef imageContext = CGBitmapContextCreate(imageData, finalWidth, finalHeight, 8, finalWidth * 4, genericRGBColorspace,  kCGBitmapByteOrder32Little | kCGImageAlphaPremultipliedFirst);
+    
+    CGContextDrawImage(imageContext, CGRectMake(0.0, 0.0, finalWidth, finalHeight), cgImageFromBytes);
+    CGImageRelease(cgImageFromBytes);
+    CGContextRelease(imageContext);
+    CGColorSpaceRelease(genericRGBColorspace);
+    CGDataProviderRelease(dataProvider);
+    
+    CVPixelBufferRef outPixelBuffer = NULL;
+    CVPixelBufferCreateWithBytes(kCFAllocatorDefault, finalWidth, finalHeight, kCVPixelFormatType_32BGRA, imageData, finalWidth * 4, NULL, NULL, NULL, &outPixelBuffer);
+    
+    CVPixelBufferLockBaseAddress(outPixelBuffer, kCVPixelBufferLock_ReadOnly);
+    size_t finalSize = CVPixelBufferGetDataSize(outPixelBuffer);
+    void *baseOutAddress = CVPixelBufferGetBaseAddress(outPixelBuffer);
+    NSData *data = [NSData dataWithBytesNoCopy:baseOutAddress length:(NSUInteger)finalSize freeWhenDone:NO];
+    CVPixelBufferUnlockBaseAddress(outPixelBuffer, kCVPixelBufferLock_ReadOnly);
+    CVPixelBufferRelease(outPixelBuffer);
+    free((void *)imageData);
+    
+    [self.consumer consumeData:data];
+    
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+    
   if (!self.pixelBufferAttributes) {
     NSDictionary<NSString *, id> *attributes = FBBitmapStreamPixelBufferAttributesFromPixelBuffer(pixelBuffer);
     self.pixelBufferAttributes = attributes;

--- a/FBSimulatorControl/Framebuffer/FBSimulatorBitmapStream.m
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorBitmapStream.m
@@ -287,10 +287,8 @@ static NSDictionary<NSString *, id> *FBBitmapStreamPixelBufferAttributesFromPixe
     CVPixelBufferUnlockBaseAddress(outPixelBuffer, kCVPixelBufferLock_ReadOnly);
     CVPixelBufferRelease(outPixelBuffer);
     free((void *)imageData);
-    
-    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-
     [consumer consumeData:data];
+    CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 }
 
 


### PR DESCRIPTION
When recording video for simulators using the command;
fbsimctl stream --bgra --fps 12 

I was getting garbled frames. I opened a thread in stack exchange as well - https://superuser.com/questions/1345998/converting-bgra-stream-to-mp4?noredirect=1#comment2016263_1345998

After playing with various pixel format transformation and reading several blogs online, this change is working as expected. I tried on iPhone X simulator with the following command;
./fbsimctl stream --bgra --fps 12 - | ffplay -f rawvideo -video_size 1125x2436  -framerate 12 -pixel_format bgra -

Please let me know if this is the right thing to do.

--Suman