### PR TITLE
Add a subcommand to enable/disable the hardware keyboard

### DIFF
--- a/FBControlCore/Reporting/FBEventConstants.h
+++ b/FBControlCore/Reporting/FBEventConstants.h
@@ -54,6 +54,7 @@ extern FBEventName const FBEventNameRecord;
 extern FBEventName const FBEventNameRelaunch;
 extern FBEventName const FBEventNameSearch;
 extern FBEventName const FBEventNameServiceInfo;
+extern FBEventName const FBEventNameSetHardwareKeyboard;
 extern FBEventName const FBEventNameSetLocation;
 extern FBEventName const FBEventNameShutdown;
 extern FBEventName const FBEventNameSignalled;

--- a/FBControlCore/Reporting/FBEventConstants.m
+++ b/FBControlCore/Reporting/FBEventConstants.m
@@ -43,6 +43,7 @@ FBEventName const FBEventNameRecord = @"record";
 FBEventName const FBEventNameRelaunch = @"relaunch";
 FBEventName const FBEventNameSearch = @"search";
 FBEventName const FBEventNameServiceInfo = @"service_info";
+FBEventName const FBEventNameSetHardwareKeyboard = @"set_hardware_keyboard";
 FBEventName const FBEventNameSetLocation = @"set_location";
 FBEventName const FBEventNameShutdown = @"shutdown";
 FBEventName const FBEventNameSignalled = @"signalled";

--- a/FBSimulatorControl/Commands/FBSimulatorBridgeCommands.h
+++ b/FBSimulatorControl/Commands/FBSimulatorBridgeCommands.h
@@ -31,6 +31,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (FBFuture<NSNull *> *)setLocationWithLatitude:(double)latitude longitude:(double)longitude;
 
+/**
+ Sets the state of the hardware keyboard connection for the Simulator.
+ Disabling the hardware keyboard might decrease flackiness for tests where automated text input is being performed, since the latter require the on-screen keyboard to be visible.
+
+ @param isEnabled wether to enable or disable the hardware keyboard.
+ @param keyboardType the keyboard type. This value should be one UIKeyboardType enumeration members.
+ @return a Future that resolves when the hardware keyboard connection state has been set.
+ */
+- (FBFuture<NSNull *> *)setHardwareKeyboardEnabled:(BOOL)isEnabled keyboardType:(unsigned char)keyboardType;
+
 @end
 
 /**

--- a/FBSimulatorControl/Commands/FBSimulatorBridgeCommands.m
+++ b/FBSimulatorControl/Commands/FBSimulatorBridgeCommands.m
@@ -56,4 +56,13 @@
     }];
 }
 
+- (FBFuture<NSNull *> *)setHardwareKeyboardEnabled:(BOOL)isEnabled keyboardType:(unsigned char)keyboardType
+{
+  return [[self.simulator
+           connectToBridge]
+          onQueue:self.simulator.workQueue fmap:^(FBSimulatorBridge *bridge) {
+            return [bridge setHardwareKeyboardEnabled:isEnabled keyboardType:keyboardType];
+          }];
+}
+
 @end

--- a/FBSimulatorControl/Management/FBSimulatorBridge.m
+++ b/FBSimulatorControl/Management/FBSimulatorBridge.m
@@ -255,6 +255,16 @@ static NSString *const SimulatorBridgePortSuffix = @"FBSimulatorControl";
     }];
 }
 
+- (FBFuture<NSNull *> *)setHardwareKeyboardEnabled:(BOOL)isEnabled keyboardType:(unsigned char)keyboardType
+{
+  return [[self
+           interactWithBridge]
+          onQueue:self.workQueue fmap:^(id<SimulatorBridge>bridge) {
+            [bridge setHardwareKeyboardEnabled:isEnabled keyboardType:keyboardType];
+            return [FBFuture futureWithResult:NSNull.null];
+          }];
+}
+
 - (FBFuture<NSNull *> *)setLocationWithLatitude:(double)latitude longitude:(double)longitude
 {
   return [[self

--- a/fbsimctl/FBSimulatorControlKit/Sources/CLIBootstrapper.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CLIBootstrapper.swift
@@ -11,7 +11,7 @@ import FBSimulatorControl
 import Foundation
 
 @objc open class CLIBootstrapper: NSObject {
-  open static func bootstrap() -> Int32 {
+  public static func bootstrap() -> Int32 {
     let arguments = Array(CommandLine.arguments.dropFirst(1))
     let environment = ProcessInfo.processInfo.environment
     let (cli, writer, reporter, _) = CLI.fromArguments(arguments, environment: environment).bootstrap()

--- a/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Command.swift
@@ -87,6 +87,7 @@ public enum Action {
   case open(URL)
   case record(Record)
   case relaunch(FBApplicationLaunchConfiguration)
+  case setHardwareKeyboard(Bool)
   case setLocation(Double, Double)
   case stream(FBBitmapStreamConfiguration, FileOutput)
   case terminate(String)
@@ -348,6 +349,8 @@ public func == (left: Action, right: Action) -> Bool {
     return leftStart == rightStart
   case (.relaunch(let leftLaunch), .relaunch(let rightLaunch)):
     return leftLaunch == rightLaunch
+  case (.setHardwareKeyboard(let leftEnabled), .setHardwareKeyboard(let rightEnabled)):
+    return leftEnabled == rightEnabled
   case (.setLocation(let leftLat, let leftLon), .setLocation(let rightLat, let rightLon)):
     return leftLat == rightLat && leftLon == rightLon
   case (.stream(let leftConfiguration, let leftOutput), .stream(let rightConfiguration, let rightOutput)):
@@ -398,6 +401,8 @@ extension Action {
       return (.record, RecordSubject(record))
     case .relaunch(let appLaunch):
       return (.relaunch, appLaunch.subject)
+    case .setHardwareKeyboard:
+      return (.setHardwareKeyboard, nil)
     case .setLocation:
       return (.setLocation, nil)
     case .stream:

--- a/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/CommandParsers.swift
@@ -525,6 +525,7 @@ extension Action: Parsable {
         self.recordParser,
         self.relaunchParser,
         self.serviceInfoParser,
+        self.setHardwareKeyboardParser,
         self.setLocationParser,
         self.shutdownParser,
         self.streamParser,
@@ -777,6 +778,22 @@ extension Action: Parsable {
         Parser<String>.ofBundleIDOrApplicationDescriptorBundleID
       )
       .fmap(Action.serviceInfo)
+  }
+
+  static var setHardwareKeyboardParser: Parser<Action> {
+    let keyboardStateParser = Parser<Bool>
+      .alternative([
+        Parser<Bool>.ofString("enabled", true),
+        Parser<Bool>.ofString("disabled", false),
+      ])
+      .fallback(true)
+
+    return Parser
+      .ofCommandWithArg(
+        EventName.setHardwareKeyboard.rawValue,
+        keyboardStateParser
+      )
+      .fmap(Action.setHardwareKeyboard)
   }
 
   static var setLocationParser: Parser<Action> {

--- a/fbsimctl/FBSimulatorControlKit/Sources/DeviceReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/DeviceReporter.swift
@@ -11,9 +11,9 @@ import FBDeviceControl
 import Foundation
 
 open class DeviceReporter: iOSReporter {
-  open unowned let device: FBDevice
-  open let reporter: EventReporter
-  open let format: FBiOSTargetFormat
+  public unowned let device: FBDevice
+  public let reporter: EventReporter
+  public let format: FBiOSTargetFormat
 
   init(device: FBDevice, format: FBiOSTargetFormat, reporter: EventReporter) {
     self.device = device

--- a/fbsimctl/FBSimulatorControlKit/Sources/SimulatorReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SimulatorReporter.swift
@@ -11,9 +11,9 @@ import FBSimulatorControl
 import Foundation
 
 open class SimulatorReporter: NSObject, FBSimulatorEventSink, iOSReporter {
-  open unowned let simulator: FBSimulator
-  open let reporter: EventReporter
-  open let format: FBiOSTargetFormat
+  public unowned let simulator: FBSimulator
+  public let reporter: EventReporter
+  public let format: FBiOSTargetFormat
 
   init(simulator: FBSimulator, format: FBiOSTargetFormat, reporter: EventReporter) {
     self.simulator = simulator

--- a/fbsimctl/FBSimulatorControlKit/Sources/SimulatorRunners.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SimulatorRunners.swift
@@ -136,6 +136,13 @@ struct SimulatorActionRunner: Runner {
     case .relaunch(var appLaunch):
       appLaunch = FBApplicationLaunchConfiguration.init(bundleID: appLaunch.bundleID, bundleName: appLaunch.bundleName, arguments: appLaunch.arguments, environment: appLaunch.environment, output: appLaunch.output, launchMode: .relaunchIfRunning)
       return FutureRunner(reporter, .relaunch, appLaunch.subject, simulator.launchApplication(appLaunch))
+    case .setHardwareKeyboard(let isEnabled):
+      return FutureRunner(
+        reporter,
+        .setHardwareKeyboard,
+        simulator.subject,
+        simulator.setHardwareKeyboardEnabled(isEnabled, keyboardType:0)
+      )
     case .setLocation(let latitude, let longitude):
       return FutureRunner(
         reporter,

--- a/fbsimctl/FBSimulatorControlKit/Sources/iOSReporter.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/iOSReporter.swift
@@ -14,7 +14,7 @@ import Foundation
  */
 public protocol iOSReporter: class {
   var reporter: EventReporter { get }
-  unowned var target: FBiOSTarget { get }
+  var target: FBiOSTarget { get }
   var format: FBiOSTargetFormat { get }
 }
 


### PR DESCRIPTION
WebDriverAgent fails to enter a text into a text field if the on-screen keyboard is not shown on the simulator and throws an error similar to the one described in https://github.com/facebook/WebDriverAgent/issues/665. With the new command it will be possible to ensure the simulator is configured properly and the keyboard is always shown if needed.

I've also fixed some compiler warnings (mostly about `open<>public` modifier usage) that were preventing fbsimctl from building on Xcode10. Please let me know if it is necessary to revert these.