### PR TITLE
Fixed an issue that prevented fbsimctl to build introduced with 789428af76082d595eeb5fe6c869ee7554b2984c

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/SignalHandler.swift
@@ -8,6 +8,9 @@
 import Foundation
 
 @objc class SignalInfo: NSObject, EventReporterSubject {
+  var eventName: FBEventName?
+  var eventType: FBEventType?
+    
   let signo: Int32
   let name: String
 

--- a/fbsimctl/FBSimulatorControlKit/Sources/Subjects.swift
+++ b/fbsimctl/FBSimulatorControlKit/Sources/Subjects.swift
@@ -33,6 +33,9 @@ extension FBJSONSerializable {
 }
 
 @objc class RecordSubject: NSObject, EventReporterSubject {
+  var eventName: FBEventName?
+  var eventType: FBEventType?
+    
   let record: Record
 
   init(_ record: Record) {
@@ -71,6 +74,9 @@ extension FBJSONSerializable {
 }
 
 @objc class ListenSubject: NSObject, EventReporterSubject {
+  var eventName: FBEventName?
+  var eventType: FBEventType?
+    
   let interface: ListenInterface
 
   init(_ interface: ListenInterface) {

--- a/fbsimctl/fbsimctl.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/fbsimctl/fbsimctl.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/fbsimctl/fbsimctl.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/fbsimctl/fbsimctl.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>IDEDidComputeMac32BitWarning</key>
-	<true/>
-</dict>
-</plist>


### PR DESCRIPTION
**Analysis:**
Commit 789428af76082d595eeb5fe6c869ee7554b2984c exposed _eventName_ and _eventType_ on _FBEventReporterSubject_. This led to the following fbsimctl classes not being able to compile due to them not conforming to the changed _FBEventReporterSubjectProtocol_:
SignalInfo
RecordSubject
ListenSubject

**Solution:**
I added protocol stubs to fix this issue. 

**Result:** 
fbsimctl is now compiling properly.