### PR TITLE
Fix typos in build script usage texts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -228,13 +228,13 @@ Supported Commands:
   framework test
     Build then Test the FBSimulatorControl.framework.
   fbsimctl build <output-directory>
-    Build the fbsimctl exectutable. Optionally copies the executable and it's dependencies to <output-directory>
+    Build the fbsimctl exectutable. Optionally copies the executable and its dependencies to <output-directory>
   fbsimctl test
     Build the FBSimulatorControlKit.framework and runs the tests.
   fbsimctl e2e-test
     Build the fbsimctl executable and run fbsimctl's e2e tests against it. Requires python3.
   fbxctest build <output-directory>
-    Build the xctest exectutable. Optionally copies the executable and it's dependencies to <output-directory>
+    Build the xctest exectutable. Optionally copies the executable and its dependencies to <output-directory>
   fbxctest test
     Builds the FBXCTestKit.framework and runs the tests.
 EOF

--- a/idb_build.sh
+++ b/idb_build.sh
@@ -156,7 +156,7 @@ Supported Commands:
   framework build <output-directory>
     Build the frameworks. Optionally copies the Framework to <output-directory>
   idb_companion build <output-directory>
-    Build the idb companion exectutable. Optionally copies the executable and it's dependencies to <output-directory>
+    Build the idb companion exectutable. Optionally copies the executable and its dependencies to <output-directory>
 EOF
 }
 


### PR DESCRIPTION
## Motivation

I was reading through the build scripts and noticed a typo in the usage text (non-native speaker here, could be completely wrong too 😄).

## Test Plan

| Before  | After |
| ------------- | ------------- |
| <img width="350" alt="before-1" src="https://user-images.githubusercontent.com/3658887/57189840-ba2bb880-6f13-11e9-9ab3-9d977b945330.png"> | <img width="350" alt="after-1" src="https://user-images.githubusercontent.com/3658887/57189851-cdd71f00-6f13-11e9-8954-6dddd07d6183.png"> |
| <img width="350" alt="before-2" src="https://user-images.githubusercontent.com/3658887/57189856-dfb8c200-6f13-11e9-9f66-940d46e93936.png"> | <img width="350" alt="after-2" src="https://user-images.githubusercontent.com/3658887/57189862-e810fd00-6f13-11e9-9313-afb5c0b47ce3.png"> |
