### PR TITLE
Add required dependencies to build idb companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ pip3 install .
 
 To build the objective-c/c++ part:
 
+Make sure you have installed gRPC dependencies: ```brew tap grpc/grpc && brew install grpc```
+
 ```
 open idb_companion.xcworkspace
 ```


### PR DESCRIPTION
## Motivation

Add required dependencies to build idb companion

## Test Plan

1. Have a fresh macOS with Xcode
2. Try to compile ```idb_companion```