### PR TITLE
[arm64e] Allow arm64 binary install on arm64e device

### DIFF
--- a/idb_companion/Utility/FBIDBStorageManager.m
+++ b/idb_companion/Utility/FBIDBStorageManager.m
@@ -100,7 +100,13 @@
   NSSet<NSString *> *bundleArchs = bundle.binary.architectures;
   NSString *targetArch = self.target.architecture;
 
-  if (![bundleArchs containsObject:targetArch]) {
+  const BOOL containsExactArch = [bundleArchs containsObject:targetArch];
+  // arm64 binaries are acceptable on arm64e devices, but arm64e is not yet available
+  const BOOL arm64eEquivalent = [bundleArchs objectsPassingTest:^BOOL(NSString *arch, BOOL * _Nonnull stop) {
+    return [arch hasPrefix:@"arm64"];
+  }] != nil;
+
+  if (!(containsExactArch || arm64eEquivalent)) {
     return [[FBIDBError
       describeFormat:@"Targets architecture %@ not in the bundles supported architectures: %@", targetArch, bundleArchs.allObjects]
       failBool:error];

--- a/idb_companion/Utility/FBIDBStorageManager.m
+++ b/idb_companion/Utility/FBIDBStorageManager.m
@@ -102,9 +102,7 @@
 
   const BOOL containsExactArch = [bundleArchs containsObject:targetArch];
   // arm64 binaries are acceptable on arm64e devices, but arm64e is not yet available
-  const BOOL arm64eEquivalent = [bundleArchs objectsPassingTest:^BOOL(NSString *arch, BOOL *_Nonnull stop) {
-    return [arch hasPrefix:@"arm64"];
-  }] != nil;
+  const BOOL arm64eEquivalent = [targetArch isEqualToString:@"arm64e"] && [bundleArchs containsObject:@"arm64"];
 
   if (!(containsExactArch || arm64eEquivalent)) {
     return [[FBIDBError

--- a/idb_companion/Utility/FBIDBStorageManager.m
+++ b/idb_companion/Utility/FBIDBStorageManager.m
@@ -102,7 +102,7 @@
 
   const BOOL containsExactArch = [bundleArchs containsObject:targetArch];
   // arm64 binaries are acceptable on arm64e devices, but arm64e is not yet available
-  const BOOL arm64eEquivalent = [bundleArchs objectsPassingTest:^BOOL(NSString *arch, BOOL * _Nonnull stop) {
+  const BOOL arm64eEquivalent = [bundleArchs objectsPassingTest:^BOOL(NSString *arch, BOOL *_Nonnull stop) {
     return [arch hasPrefix:@"arm64"];
   }] != nil;
 


### PR DESCRIPTION
## Motivation

arm64e devices are fully capable of running an arm64 binary, so the
conditional that only included the arm64 definition was too restrictive.

## Test Plan

- Create new Xcode project
- Remove arm64e from the list of `Valid Architectures`
- Build with Xcode

Before
```
[~]
 »»»» idb connect localhost 10882
udid: 00008020-000879613E78002E is_local: True
[~]
 »»»» idb install /Users/amonshiz/Library/Developer/Xcode/DerivedData/ASanTesting-hivuifodmjohvhdgbptymydwresl/Build/Products/Debug-iphoneos/ASanTesting.app
Targets architecture arm64e not in the bundles supported architectures: (
    arm64
)
```

After
```
[~]
 »»»» idb connect localhost 10882
udid: 00008020-000879613E78002E is_local: True
[~]
 »»»» idb install /Users/amonshiz/Library/Developer/Xcode/DerivedData/ASanTesting-hivuifodmjohvhdgbptymydwresl/Build/Products/Debug-iphoneos/ASanTesting.app
Installed: com.amonshiz.ASanTesting 7959C4C6-CA4B-3932-9D5C-F1966B1976F5
```