### PR TITLE
Fix XCTestBootstrap build failure

### DIFF
--- a/FBSimulatorControl.xcodeproj/project.pbxproj
+++ b/FBSimulatorControl.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		05E1E34E1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 05E1E34C1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05E1E34F1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m in Sources */ = {isa = PBXBuildFile; fileRef = 05E1E34D1E3DBA87004F67B8 /* FBTestManagerJUnitGenerator.m */; };
 		05F1823F1D59B48600DBD35C /* junitResult1.xml in Resources */ = {isa = PBXBuildFile; fileRef = 05F1823E1D59B48600DBD35C /* junitResult1.xml */; };
+		1F6F440E239B6A55001C7F72 /* FBXCTestResultToolOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F6F440C239B6A55001C7F72 /* FBXCTestResultToolOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F6F440F239B6A55001C7F72 /* FBXCTestResultToolOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F6F440D239B6A55001C7F72 /* FBXCTestResultToolOperation.m */; };
 		1F7596B31DFF6B40006B9053 /* libShimulator.dylib in Resources */ = {isa = PBXBuildFile; fileRef = AA017F4C1BD7784700F45E9D /* libShimulator.dylib */; };
 		2F8294CE1FBC571B0011E722 /* FBLogicReporterAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F8294CA1FBC571B0011E722 /* FBLogicReporterAdapter.m */; };
 		2F8294D01FBC5AAE0011E722 /* FBLogicReporterAdapterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F8294CF1FBC5AAE0011E722 /* FBLogicReporterAdapterTests.m */; };
@@ -786,6 +788,8 @@
 		1DD70E29A6018C7A00000000 /* CoreGraphics.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
 		1DD70E29B67B6FA500000000 /* DVTFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = DVTFoundation.framework; path = ../SharedFrameworks/DVTFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		1DD70E29B6970A5500000000 /* CoreSimulator.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = CoreSimulator.framework; path = Library/PrivateFrameworks/CoreSimulator.framework; sourceTree = DEVELOPER_DIR; };
+		1F6F440C239B6A55001C7F72 /* FBXCTestResultToolOperation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBXCTestResultToolOperation.h; sourceTree = "<group>"; };
+		1F6F440D239B6A55001C7F72 /* FBXCTestResultToolOperation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FBXCTestResultToolOperation.m; sourceTree = "<group>"; };
 		2F8294C71FBC571A0011E722 /* FBJSONTestReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBJSONTestReporter.h; sourceTree = "<group>"; };
 		2F8294C81FBC571A0011E722 /* FBLogicXCTestReporter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBLogicXCTestReporter.h; sourceTree = "<group>"; };
 		2F8294C91FBC571A0011E722 /* FBLogicReporterAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FBLogicReporterAdapter.h; sourceTree = "<group>"; };
@@ -2814,6 +2818,8 @@
 		EE4F0D691C91B82700608E89 /* Utility */ = {
 			isa = PBXGroup;
 			children = (
+				1F6F440C239B6A55001C7F72 /* FBXCTestResultToolOperation.h */,
+				1F6F440D239B6A55001C7F72 /* FBXCTestResultToolOperation.m */,
 				AABD06B11EE7B84F00135D27 /* FBXcodeBuildOperation.h */,
 				AABD06B21EE7B84F00135D27 /* FBXcodeBuildOperation.m */,
 				AAE5A07F1EDF8C9C00A1A811 /* FBXCTestLogger.h */,
@@ -3257,6 +3263,7 @@
 				AA83EB211D7023F200E5C864 /* FBTestDaemonResult.h in Headers */,
 				AA7FA7AA1CDCF26E00614A61 /* FBTestManagerResultSummary.h in Headers */,
 				2F8294D31FBC798C0011E722 /* FBLogicXCTestReporter.h in Headers */,
+				1F6F440E239B6A55001C7F72 /* FBXCTestResultToolOperation.h in Headers */,
 				EE2586FD1FB072F700E7526E /* FBMacTestPreparationStrategy.h in Headers */,
 				AA6062EE1EE4A96D00E2EFEE /* FBMacXCTestProcessExecutor.h in Headers */,
 				AA6062EA1EE4A6B100E2EFEE /* FBXCTestProcess.h in Headers */,
@@ -3875,6 +3882,7 @@
 				842A2B741F6AC89C00063EB1 /* FBActivityRecord.m in Sources */,
 				AA46BF611D6DDC6A00C41DAF /* FBTestManagerContext.m in Sources */,
 				3E14993D1D4C5042005A5C8F /* FBTestManagerTestReporterJUnit.m in Sources */,
+				1F6F440F239B6A55001C7F72 /* FBXCTestResultToolOperation.m in Sources */,
 				EE4F0D7E1C91B82700608E89 /* FBTestRunnerConfiguration.m in Sources */,
 				AA1F2C8B1CEA4176003E0BDE /* XCTestBootstrapFrameworkLoader.m in Sources */,
 				3E1499451D4C574F005A5C8F /* FBTestManagerTestReporterTestSuite.m in Sources */,


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

After commit of af353430, idb builds have been failed, and `brew install idb-companion --HEAD` will also fail (shown below).
This pull request will fix that problem.

```
$  brew install idb-companion --HEAD
==> Installing idb-companion from facebook/fb
==> Cloning https://github.com/facebook/idb.git
Cloning into '/Users/hnisiji/Library/Caches/Homebrew/idb-companion--git'...
==> Checking out branch master
Already on 'master'
Your branch is up to date with 'origin/master'.
==> ./idb_build.sh idb_companion build /usr/local/Cellar/idb-companion/HEAD-af35343
Last 15 lines from /Users/hnisiji/Library/Logs/Homebrew/idb-companion/01.idb_build.sh:
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/idb-companion-20191207-49198-12h7jyo/XCTestBootstrap/XCTestBootstrap.h:44:9: note: did not find header 'FBXCTestResultToolOperation.h' in framework 'XCTestBootstrap' (loaded from '/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Products/Debug')
1 error generated.

CompileC /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/Objects-normal/x86_64/FBXCTestReporterAdapter.o /tmp/idb-companion-20191207-49198-12h7jyo/XCTestBootstrap/Reporters/FBXCTestReporterAdapter.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler (in target 'XCTestBootstrap' from project 'FBSimulatorControl')
    cd /tmp/idb-companion-20191207-49198-12h7jyo
    export LANG=en_US.US-ASCII
    clang -x objective-c -target x86_64-apple-macos10.10 -fmessage-length=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit=0 -std=gnu99 -fobjc-arc -fmodules -gmodules -fmodules-cache-path=/tmp/idb-companion-20191207-49198-12h7jyo/build/ModuleCache.noindex -fmodules-prune-interval=86400 -fmodules-prune-after=345600 -fbuild-session-file=/tmp/idb-companion-20191207-49198-12h7jyo/build/ModuleCache.noindex/Session.modulevalidation -fmodules-validate-once-per-build-session -Wnon-modular-include-in-framework-module -Werror=non-modular-include-in-framework-module -fmodule-name=XCTestBootstrap -Wno-trigraphs -fpascal-strings -O0 -fno-common -Werror -Werror=incompatible-pointer-types -Werror=implicit-function-declaration -Wmissing-field-initializers -Wmissing-prototypes -Wdocumentation -Wunreachable-code -Wno-implicit-atomic-properties -Werror=deprecated-objc-isa-usage -Wno-objc-interface-ivars -Werror=objc-root-class -Wno-arc-repeated-use-of-weak -Wimplicit-retain-self -Wmissing-braces -Wparentheses -Wswitch -Wunused-function -Wunused-label -Wno-unused-parameter -Wunused-variable -Wunused-value -Wempty-body -Wuninitialized -Wconditional-uninitialized -Wunknown-pragmas -Wshadow -Wfour-char-constants -Wconversion -Wconstant-conversion -Wint-conversion -Wbool-conversion -Wenum-conversion -Wfloat-conversion -Wnon-literal-null-conversion -Wobjc-literal-conversion -Wsign-compare -Wshorten-64-to-32 -Wpointer-sign -Wnewline-eof -Wno-selector -Wno-strict-selector-match -Wundeclared-selector -Wdeprecated-implementations -DDEBUG=1 -DOBJC_OLD_DISPATCH_PROTOTYPES=0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk -fasm-blocks -fstrict-aliasing -Wprotocol -Wdeprecated-declarations -g -Wsign-conversion -Winfinite-recursion -Wcomma -Wblock-capture-autoreleasing -Wstrict-prototypes -Wno-semicolon-before-method-body -index-store-path /tmp/idb-companion-20191207-49198-12h7jyo/build/Index/DataStore -iquote /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/XCTestBootstrap-generated-files.hmap -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/XCTestBootstrap-own-target-headers.hmap -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/XCTestBootstrap-all-non-framework-target-headers.hmap -ivfsoverlay /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/all-product-headers.yaml -iquote /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/XCTestBootstrap-project-headers.hmap -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Products/Debug/include -I/tmp/idb-companion-20191207-49198-12h7jyo/PrivateHeaders -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/DerivedSources-normal/x86_64 -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/DerivedSources/x86_64 -I/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/DerivedSources -F/tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Products/Debug -F/Applications/Xcode.app/Contents/Frameworks -F/Applications/Xcode.app/Contents/PlugIns -F/Applications/Xcode.app/Contents/OtherFrameworks -F/Applications/Xcode.app/Contents/SharedFrameworks -F/Applications/Xcode.app/Contents/Developer/Library/PrivateFrameworks -F/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.15.sdk/System/Library/PrivateFrameworks -F/Library/Developer/PrivateFrameworks -MMD -MT dependencies -MF /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/Objects-normal/x86_64/FBXCTestReporterAdapter.d --serialize-diagnostics /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/Objects-normal/x86_64/FBXCTestReporterAdapter.dia -c /tmp/idb-companion-20191207-49198-12h7jyo/XCTestBootstrap/Reporters/FBXCTestReporterAdapter.m -o /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/Objects-normal/x86_64/FBXCTestReporterAdapter.o

** BUILD FAILED **


The following build commands failed:
	CompileC /tmp/idb-companion-20191207-49198-12h7jyo/build/Build/Intermediates.noindex/FBSimulatorControl.build/Debug/XCTestBootstrap.build/Objects-normal/x86_64/FBXCTestRunStrategy.o /tmp/idb-companion-20191207-49198-12h7jyo/XCTestBootstrap/Strategies/FBXCTestRunStrategy.m normal x86_64 objective-c com.apple.compilers.llvm.clang.1_0.compiler
(1 failure)

If reporting this issue please do so at (not Homebrew/brew or Homebrew/core):
  https://github.com/facebook/homebrew-fb/issues
```


## Test Plan
- Make sure to succeed `./idb_build.sh idb_companion build  ./dist`

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
