### PR TITLE
Fix to work `fbsimctl list`

### DIFF
--- a/fbsimctl/FBSimulatorControlKit/Swift/Parser.swift
+++ b/fbsimctl/FBSimulatorControlKit/Swift/Parser.swift
@@ -230,7 +230,7 @@ extension Parser {
     }
 
     let sequentialParser = Parser<()>
-      .ofFlag(flag, explanation)
+      .ofFlag(flag, (), explanation)
       .sequence(arg)
     return Parser<A>.alternative([equalParser, sequentialParser])
   }


### PR DESCRIPTION
## Motivation
I fixed the fbsimctl bug reported in #537.
I know fbsimctl is no longer supported, but there are some useful features not yet available in idb, such as stream, so I want to fix it.

## Test Plan
- Build and run `fbsimctl list`
