### PR TITLE
bugfix for sdist installing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/facebook/idb",
     packages=setuptools.find_packages(),
+    data_files=[("proto", ["proto/idb.proto"])],
     license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3.6",


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We have forked a branch for secondary development, we need to distribute fb-idb to our own pypi server, we build only tarball to pypi server, and when client installs from tarball, an error occurs.

## Test Plan

```shell
python3 setup.py sdist
pip3 install dist/fb-idb-0.0.1.tar.gz --user
```

![image](https://user-images.githubusercontent.com/22538408/76180431-e16ca980-61f8-11ea-9541-358ebc42676a.png)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
