### PR TITLE
dynamiclly generate protoc compiler to avoid installing error for tarball

### DIFF
--- a/protoc_compiler_template.py
+++ b/protoc_compiler_template.py
@@ -1,0 +1,11 @@
+# EASY-INSTALL-ENTRY-SCRIPT: 'grpclib==0.3.1','console_scripts','protoc-gen-python_grpc'
+__requires__ = 'grpclib==0.3.1'
+import re
+import sys
+from pkg_resources import load_entry_point
+
+if __name__ == '__main__':
+    sys.argv[0] = re.sub(r'(-script\.pyw?|\.exe)?$', '', sys.argv[0])
+    sys.exit(
+        load_entry_point('grpclib==0.3.1', 'console_scripts', 'protoc-gen-python_grpc')()
+    )


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

This pull request mainly fixes issue #589 . To ensure the generated proto file to be pure python(see #591 ), I add some code to dynamically generate the expected compiler `protoc-gen-python_grpc` at the root directory, and add root directory to PATH variable.

## Test Plan

1. `rm /usr/local/bin/protoc-gen-python_grpc` since user environment has no such file.

2. disable the `gen_protoc_compiler()` invocation in `setup.BuildPyCommand.run`

3. `python3 setup.py install` and we'll get an error complaining about `protoc-gen-python_grpc` not found

4. enable the `gen_protoc_compiler()` invocation in `setup.BuildPyCommand.run`

5. `python3 setup.py install` will end in success.
## Related PRs


