### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,10 +6,6 @@
  */
 
 module.exports = {
-  algolia: {
-    apiKey: '0908032af0955efe731222e1de3bad86',
-    indexName: 'idb'
-  },
   title: 'idb',
   tagline: 'iOS Development Bridge',
   favicon: 'img/favicon.png',
@@ -18,6 +14,10 @@ module.exports = {
   organizationName: 'facebook',
   projectName: 'idb',
   themeConfig: {
+    algolia: {
+      apiKey: '0908032af0955efe731222e1de3bad86',
+      indexName: 'idb'
+    },
     navbar: {
       title: 'idb',
       links: [

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -6,6 +6,10 @@
  */
 
 module.exports = {
+  algolia: {
+    apiKey: '0908032af0955efe731222e1de3bad86',
+    indexName: 'idb'
+  },
   title: 'idb',
   tagline: 'iOS Development Bridge',
   favicon: 'img/favicon.png',


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.