### PR TITLE
Fixed use of FBApplicationLaunchMode for FBDevice

### DIFF
--- a/FBDeviceControl/Management/FBInstrumentsClient.m
+++ b/FBDeviceControl/Management/FBInstrumentsClient.m
@@ -140,7 +140,8 @@ static NSString *const ProcessControlChannel = @"com.apple.instruments.server.se
     onQueue:self.queue resolveValue:^ NSNumber * (NSError **error) {
       NSDictionary<NSString *, NSNumber *> *options = @{
         @"StartSuspendedKey": @(configuration.waitForDebugger),
-        @"KillExisting": @(configuration.launchMode != FBApplicationLaunchModeFailIfRunning),
+        // FBApplicationLaunchModeFailIfRunning needs to be taken care of prior to this call.
+        @"KillExisting": @(configuration.launchMode == FBApplicationLaunchModeRelaunchIfRunning),
       };
       ResponsePayload response = [self
         onChannelIdentifier:ProcessControlChannel


### PR DESCRIPTION
## Motivation

Previously, an Application on a device would be restarted for FBApplicationLaunchModeForegroundIfRunning and not fail if already running for FBApplicationLaunchModeFailIfRunning.

## Test Plan

Tested this manually with an application that calls directly into FBDeviceControl framework.
This application in turn has some automated tests that capture this behavior (this is how I found the issue).
I have not added any tests to idb, but will happily do so if someone can point me to it (I'm still new to the project).

## Related PRs

-