### PR TITLE
Fixed use of FBApplicationLaunchMode for FBDevice

### DIFF
--- a/FBDeviceControl/Commands/FBDeviceApplicationCommands.m
+++ b/FBDeviceControl/Commands/FBDeviceApplicationCommands.m
@@ -238,6 +238,26 @@ static void TransferCallback(NSDictionary<NSString *, id> *callbackDictionary, i
 
 - (FBFuture<id<FBLaunchedApplication>> *)launchApplication:(FBApplicationLaunchConfiguration *)configuration
 {
+  if (configuration.launchMode == FBApplicationLaunchModeFailIfRunning) {
+    return [[self processIDWithBundleID:configuration.bundleID] onQueue:self.device.asyncQueue chain:^ (FBFuture<NSNumber *>* processIdQueryResult) {
+      if (processIdQueryResult.state == FBFutureStateDone) {
+        return [[FBDeviceControlError
+          describeFormat:@"Application %@ already running with pid %@", configuration.bundleID, processIdQueryResult.result]
+          failFuture];
+      } else if (processIdQueryResult.state == FBFutureStateFailed) {
+        return (FBFuture*)[self launchApplicationIgnoreCurrentState:configuration];
+      } else {
+        return (FBFuture*)processIdQueryResult;
+      }
+    }];
+  }
+  return [self launchApplicationIgnoreCurrentState:configuration];
+}
+
+#pragma mark Private
+
+- (FBFuture<id<FBLaunchedProcess>> *)launchApplicationIgnoreCurrentState:(FBApplicationLaunchConfiguration *)configuration
+{
   return [[[self
     remoteInstrumentsClient]
     onQueue:self.device.asyncQueue pop:^(FBInstrumentsClient *client) {
@@ -247,8 +267,6 @@ static void TransferCallback(NSDictionary<NSString *, id> *callbackDictionary, i
       return [[FBDeviceLaunchedApplication alloc] initWithProcessIdentifier:pid.intValue commands:self queue:self.device.workQueue];
     }];
 }
-
-#pragma mark Private
 
 - (FBFuture<NSNull *> *)killApplicationWithProcessIdentifier:(pid_t)processIdentifier
 {

--- a/FBDeviceControl/Management/FBInstrumentsClient.m
+++ b/FBDeviceControl/Management/FBInstrumentsClient.m
@@ -140,7 +140,8 @@ static NSString *const ProcessControlChannel = @"com.apple.instruments.server.se
     onQueue:self.queue resolveValue:^ NSNumber * (NSError **error) {
       NSDictionary<NSString *, NSNumber *> *options = @{
         @"StartSuspendedKey": @(configuration.waitForDebugger),
-        @"KillExisting": @(configuration.launchMode != FBApplicationLaunchModeFailIfRunning),
+        // FBApplicationLaunchModeFailIfRunning needs to be taken care of prior to this call.
+        @"KillExisting": @(configuration.launchMode == FBApplicationLaunchModeRelaunchIfRunning),
       };
       ResponsePayload response = [self
         onChannelIdentifier:ProcessControlChannel


### PR DESCRIPTION
## Motivation

Previously, an Application on a device would be restarted for FBApplicationLaunchModeForegroundIfRunning and not fail if already running for FBApplicationLaunchModeFailIfRunning.

## Test Plan

Tested this manually with an application that calls directly into FBDeviceControl framework.
This application in turn has some automated tests that capture this behavior (this is how I found the issue).
I have not added any tests to idb, but will happily do so if someone can point me to it (I'm still new to the project).

## Related PRs

n/a