### PR TITLE
Docs: idb file pull cmd adjusted

### DIFF
--- a/website/docs/commands.mdx
+++ b/website/docs/commands.mdx
@@ -207,7 +207,7 @@ Copies one or more files from the host to the relative destination path within t
 ### Copying files out of a container
 
 ```
-idb file pull --bundle-id com.foo.bar src.txt dest.txt
+idb file pull --bundle-id com.foo.bar src.txt dest/
 ```
 
 Copies a single file from the container to the host.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

Fixed this command example on the website: `idb file pull --bundle-id com.foo.bar src.txt dest.txt`. The last argument should be the target **directory** on the host, not the file name.

## Test Plan

If you run `idb file pull --bundle-id com.foo.bar src.txt dest.txt`, it will create `dest.txt/src.txt` on the host.
