### PR TITLE
Fix build on Apple Silicon

### DIFF
--- a/idb/cli/main.py
+++ b/idb/cli/main.py
@@ -141,7 +141,9 @@ async def gen_main(cmd_input: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--companion-path",
         type=str,
-        default="/usr/local/bin/idb_companion" if shutil.which('idb_companion') is None else shutil.which('idb_companion'),
+        default="/usr/local/bin/idb_companion"
+        if shutil.which("idb_companion") is None
+        else shutil.which("idb_companion"),
         help="The path to the idb companion binary. This is only valid when running on macOS platforms",
     )
     parser.add_argument(

--- a/idb/cli/main.py
+++ b/idb/cli/main.py
@@ -10,6 +10,7 @@ import concurrent.futures
 import logging
 import os
 import sys
+import shutil
 from typing import List, Optional, Set
 
 import idb.common.plugin as plugin
@@ -140,7 +141,7 @@ async def gen_main(cmd_input: Optional[List[str]] = None) -> int:
     parser.add_argument(
         "--companion-path",
         type=str,
-        default="/usr/local/bin/idb_companion" if sys.platform == "darwin" else None,
+        default="/usr/local/bin/idb_companion" if shutil.which('idb_companion') is None else shutil.which('idb_companion'),
         help="The path to the idb companion binary. This is only valid when running on macOS platforms",
     )
     parser.add_argument(

--- a/idb_companion.xcodeproj/project.pbxproj
+++ b/idb_companion.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE).grpc.pb.h",
 				"$(DERIVED_FILE_DIR)/$(INPUT_FILE_BASE).grpc.pb.cc",
 			);
-			script = "# Generate grpc code from .proto\nprotoc --proto_path=$INPUT_FILE_DIR --cpp_out=$DERIVED_FILE_DIR --grpc_out=$DERIVED_FILE_DIR --plugin=protoc-gen-grpc=/usr/local/bin/grpc_cpp_plugin $INPUT_FILE_PATH\n\n# Copy headers\nmkdir -p ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\ncp -a ${DERIVED_FILES_DIR}/*.h ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\n";
+			script = "# Generate grpc code from .proto\nPATH=$PATH:/opt/homebrew/bin/:/usr/local/bin\n\nprotoc --proto_path=$INPUT_FILE_DIR --cpp_out=$DERIVED_FILE_DIR --grpc_out=$DERIVED_FILE_DIR --plugin=protoc-gen-grpc=$(brew --prefix)/bin/grpc_cpp_plugin $INPUT_FILE_PATH\n\n# Copy headers\nmkdir -p ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\ncp -a ${DERIVED_FILES_DIR}/*.h ${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}\n";
 		};
 /* End PBXBuildRule section */
 
@@ -573,11 +573,15 @@
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = (
 					/usr/local/include,
+					/opt/homebrew/include,
 					"$(BUILT_PRODUCTS_DIR)/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/idb_companion/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = /usr/local/lib;
+				LIBRARY_SEARCH_PATHS = (
+					/usr/local/lib,
+					/opt/homebrew/lib,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -590,11 +594,15 @@
 				DEVELOPMENT_TEAM = "";
 				HEADER_SEARCH_PATHS = (
 					/usr/local/include,
+					/opt/homebrew/include,
 					"$(BUILT_PRODUCTS_DIR)/**",
 				);
 				INFOPLIST_FILE = "$(SRCROOT)/idb_companion/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/../Frameworks";
-				LIBRARY_SEARCH_PATHS = /usr/local/lib;
+				LIBRARY_SEARCH_PATHS = (
+					/usr/local/lib,
+					/opt/homebrew/lib,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 			};
@@ -606,8 +614,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				EXECUTABLE_PREFIX = lib;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
-				HEADER_SEARCH_PATHS = " /usr/local/include";
-				LIBRARY_SEARCH_PATHS = /usr/local/lib;
+				HEADER_SEARCH_PATHS = (
+					/usr/local/include,
+					/opt/homebrew/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					/usr/local/lib,
+					/opt/homebrew/lib,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -619,8 +633,14 @@
 				CODE_SIGN_STYLE = Automatic;
 				EXECUTABLE_PREFIX = lib;
 				GCC_WARN_INHIBIT_ALL_WARNINGS = YES;
-				HEADER_SEARCH_PATHS = " /usr/local/include";
-				LIBRARY_SEARCH_PATHS = /usr/local/lib;
+				HEADER_SEARCH_PATHS = (
+					/usr/local/include,
+					/opt/homebrew/include,
+				);
+				LIBRARY_SEARCH_PATHS = (
+					/usr/local/lib,
+					/opt/homebrew/lib,
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/master/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

`brew install facebook/fb/idb-companion` on Apple M1 devices is broken.

## Test Plan

1. Open `idb_companion.xcworkspace` on Apple M1 devices, then `CMD+R` to build `idb_companion`.
2. Or execute `./idb_build.sh idb_companion build` on Apple M1 devices to build `idb_companion`

## Related PRs

No.
