### PR TITLE
Fix typo in launch command section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ com.apple.mobileslideshow | MobileSlideShow | system | x86_64 | Not running | No
 com.apple.mobilesafari | MobileSafari | system | x86_64 | Not running | Not Debuggable
 ```
 
-`launch` will launch an application the application:
+`launch` will launch an application:
 
 ```
 $ idb launch com.apple.mobilesafari


### PR DESCRIPTION
## Motivation

Resolves a typo in README.md. Closes #679.

## Test Plan

Visual inspection of the sentence before and after typo fix.

### Before fix:
![CleanShot 2021-06-17 at 18 05 51](https://user-images.githubusercontent.com/40807488/122490380-b98cf980-cf96-11eb-9dae-da20e6c3da9d.png)

### After fix:
![CleanShot 2021-06-17 at 18 07 29](https://user-images.githubusercontent.com/40807488/122490456-e5a87a80-cf96-11eb-99e0-3c3627e4a268.png)

