### PR TITLE
Fix comparison warning of integers of different signs

### DIFF
--- a/FBControlCore/Utility/FBVideoStream.m
+++ b/FBControlCore/Utility/FBVideoStream.m
@@ -12,7 +12,7 @@
 #import "FBControlCoreLogger.h"
 #import "FBDataConsumer.h"
 
-static NSUInteger const MaxAllowedUnprocessedDataCounts = 10;
+static NSInteger const MaxAllowedUnprocessedDataCounts = 10;
 
 BOOL checkConsumerBufferLimit(id<FBDataConsumer> consumer, id<FBControlCoreLogger> logger) {
   if ([consumer conformsToProtocol:@protocol(FBDataConsumerAsync)]) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

The signs of `framesInProcess` (NSInteger) and `MaxAllowedUnprocessedDataCounts` (NSUInteger) do not match, resulting in a warning when comparing.

## Test Plan

(Since we have only fix minor warnings, I don't think we need to test it.)

## Related PRs
