### PR TITLE
fix(website docs): fix project name in `overview.md`.

### DIFF
--- a/website/docs/overview.mdx
+++ b/website/docs/overview.mdx
@@ -3,4 +3,4 @@ id: overview
 title: Overview
 ---
 
-iOS Debug Bridge (idb) is a versatile tool for automating iOS Simulators & Devices. It exposes a lot of functionality that is spread over Apple's tools in a consistent and human-friendly interface.
+iOS Development Bridge (idb) is a versatile tool for automating iOS Simulators & Devices. It exposes a lot of functionality that is spread over Apple's tools in a consistent and human-friendly interface.


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation
Reading the website docs, I've noticed that the project name in the _"Overview"_ page is "iOS Debug Bridge" and not "iOS Development Bridge" as used in all other places. 🙂 