### PR TITLE
Feature/xcode 13 instruments support

### DIFF
--- a/FBControlCore/Utility/FBInstrumentsOperation.m
+++ b/FBControlCore/Utility/FBInstrumentsOperation.m
@@ -15,6 +15,7 @@
 #import "FBInstrumentsConfiguration.h"
 #import "FBiOSTarget.h"
 #import "FBProcessBuilder.h"
+#import "FBXcodeConfiguration.h"
 
 const NSTimeInterval DefaultInstrumentsOperationDuration = 60 * 60 * 4;
 const NSTimeInterval DefaultInstrumentsTerminateTimeout = 600.0;
@@ -102,27 +103,17 @@ const NSTimeInterval DefaultInstrumentsLaunchRetryTimeout = 360.0;
   }
   NSString *traceFile = [traceDir stringByAppendingPathComponent:@"trace.trace"];
 
-  NSString *durationMilliseconds = [@(configuration.timings.operationDuration * 1000) stringValue];
-  NSMutableArray<NSString *> *arguments = [NSMutableArray new];
-  if ([[configuration toolArguments] count] > 0) {
-    [arguments addObjectsFromArray:[configuration toolArguments]];
-  }
-  [arguments addObjectsFromArray:@[@"-w", target.udid, @"-D", traceFile, @"-t", configuration.templateName, @"-l",  durationMilliseconds, @"-v"]];
-
-  if (configuration.targetApplication && [configuration.targetApplication length] > 0) {
-    [arguments addObject:configuration.targetApplication];
-    for (NSString *key in configuration.appEnvironment) {
-      [arguments addObjectsFromArray:@[@"-e", key, configuration.appEnvironment[key]]];
-    }
-    [arguments addObjectsFromArray:configuration.appArguments];
-  }
+  NSArray<NSString *> *arguments = [self createArgumentsWithTarget:target
+                                          configuration:configuration
+                                              traceFile:traceFile];
+  
   [logger logFormat:@"Starting instruments with arguments: %@", [FBCollectionInformation oneLineDescriptionFromArray:arguments]];
   FBInstrumentsConsumer *instrumentsConsumer = [[FBInstrumentsConsumer alloc] init];
   id<FBControlCoreLogger> instrumentsLogger = [FBControlCoreLogger loggerToConsumer:instrumentsConsumer];
   id<FBControlCoreLogger> compositeLogger = [FBControlCoreLogger compositeLoggerWithLoggers:@[logger, instrumentsLogger]];
 
   return [[[[[[[[FBProcessBuilder
-    withLaunchPath:@"/usr/bin/instruments"]
+    withLaunchPath:[self launchPath]]
     withArguments:arguments]
     withStdOutToLogger:compositeLogger]
     withStdErrToLogger:compositeLogger]
@@ -216,33 +207,55 @@ const NSTimeInterval DefaultInstrumentsLaunchRetryTimeout = 360.0;
 
 + (NSArray *)createArgumentsWithTarget:(id<FBiOSTarget>)target
                          configuration:(FBInstrumentsConfiguration *)configuration
-                             traceFile: (NSString *)traceFile {
+                             traceFile: (NSString *)traceFile
+{
   NSString *durationMilliseconds = [NSString stringWithFormat:@"%@ms", [@(configuration.timings.operationDuration * 1000) stringValue]];
   
-  NSMutableArray<NSString *> *arguments = [NSMutableArray new];
-  [arguments addObjectsFromArray:@[@"--template", configuration.templateName,
-                                   @"--device", target.udid,
-                                   @"--output", traceFile,
-                                   @"--time-limit", durationMilliseconds]];
-  
-  if (configuration.targetApplication && [configuration.targetApplication length] > 0) {
-    for (NSString *key in configuration.appEnvironment) {
-      [arguments addObjectsFromArray:@[@"--env", [NSString stringWithFormat:@"%@=%@", key, configuration.appEnvironment[key]]]];
+  if (FBXcodeConfiguration.isXcode13OrGreater) {
+    NSMutableArray<NSString *> *arguments = [NSMutableArray new];
+    [arguments addObjectsFromArray:@[@"--template", configuration.templateName,
+                                     @"--device", target.udid,
+                                     @"--output", traceFile,
+                                     @"--time-limit", durationMilliseconds]];
+    
+    if (configuration.targetApplication && [configuration.targetApplication length] > 0) {
+      for (NSString *key in configuration.appEnvironment) {
+        [arguments addObjectsFromArray:@[@"--env", [NSString stringWithFormat:@"%@=%@", key, configuration.appEnvironment[key]]]];
+      }
+      
+      [arguments addObjectsFromArray:@[
+        @"--launch",
+        @"--",
+        configuration.targetApplication
+      ]];
+      [arguments addObjectsFromArray:configuration.appArguments];
     }
     
-    [arguments addObjectsFromArray:@[
-      @"--launch",
-      @"--",
-      configuration.targetApplication
-    ]];
-    [arguments addObjectsFromArray:configuration.appArguments];
+    return [@[@"xctrace", @"record"] arrayByAddingObjectsFromArray:arguments];
+  } else {
+    NSMutableArray<NSString *> *arguments = [NSMutableArray new];
+    if ([[configuration toolArguments] count] > 0) {
+      [arguments addObjectsFromArray:[configuration toolArguments]];
+    }
+    [arguments addObjectsFromArray:@[@"-w", target.udid, @"-D", traceFile, @"-t", configuration.templateName, @"-l",  durationMilliseconds, @"-v"]];
+
+    if (configuration.targetApplication && [configuration.targetApplication length] > 0) {
+      [arguments addObject:configuration.targetApplication];
+      for (NSString *key in configuration.appEnvironment) {
+        [arguments addObjectsFromArray:@[@"-e", key, configuration.appEnvironment[key]]];
+      }
+      [arguments addObjectsFromArray:configuration.appArguments];
+    }
+    
+    return arguments;
   }
-  
-  return [@[@"xctrace", @"record"] arrayByAddingObjectsFromArray:arguments];
 }
 
+
 + (NSString *)launchPath {
-  return @"/usr/bin/xcrun";
+  return FBXcodeConfiguration.isXcode13OrGreater ?
+    @"/usr/bin/xcrun" :
+    @"/usr/bin/instruments";
 }
 
 @end

--- a/FBControlCore/Utility/FBInstrumentsOperation.m
+++ b/FBControlCore/Utility/FBInstrumentsOperation.m
@@ -212,4 +212,37 @@ const NSTimeInterval DefaultInstrumentsLaunchRetryTimeout = 360.0;
     }];
 }
 
+#pragma mark Private Methods
+
++ (NSArray *)createArgumentsWithTarget:(id<FBiOSTarget>)target
+                         configuration:(FBInstrumentsConfiguration *)configuration
+                             traceFile: (NSString *)traceFile {
+  NSString *durationMilliseconds = [NSString stringWithFormat:@"%@ms", [@(configuration.timings.operationDuration * 1000) stringValue]];
+  
+  NSMutableArray<NSString *> *arguments = [NSMutableArray new];
+  [arguments addObjectsFromArray:@[@"--template", configuration.templateName,
+                                   @"--device", target.udid,
+                                   @"--output", traceFile,
+                                   @"--time-limit", durationMilliseconds]];
+  
+  if (configuration.targetApplication && [configuration.targetApplication length] > 0) {
+    for (NSString *key in configuration.appEnvironment) {
+      [arguments addObjectsFromArray:@[@"--env", [NSString stringWithFormat:@"%@=%@", key, configuration.appEnvironment[key]]]];
+    }
+    
+    [arguments addObjectsFromArray:@[
+      @"--launch",
+      @"--",
+      configuration.targetApplication
+    ]];
+    [arguments addObjectsFromArray:configuration.appArguments];
+  }
+  
+  return [@[@"xctrace", @"record"] arrayByAddingObjectsFromArray:arguments];
+}
+
++ (NSString *)launchPath {
+  return @"/usr/bin/xcrun";
+}
+
 @end

--- a/FBControlCore/Utility/FBXcodeConfiguration.h
+++ b/FBControlCore/Utility/FBXcodeConfiguration.h
@@ -73,6 +73,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly, class) BOOL isXcode12_5OrGreater;
 
 /**
+ YES if Xcode 13 or greater, NO Otherwise.
+ */
+@property (nonatomic, assign, readonly, class) BOOL isXcode13OrGreater;
+
+/**
  A Description of the Current Configuration.
  */
 @property (nonatomic, copy, readonly, class) NSString *description;

--- a/FBControlCore/Utility/FBXcodeConfiguration.m
+++ b/FBControlCore/Utility/FBXcodeConfiguration.m
@@ -105,6 +105,11 @@
   return [FBXcodeConfiguration.xcodeVersionNumber compare:[NSDecimalNumber decimalNumberWithString:@"12.5"]] != NSOrderedAscending;
 }
 
++ (BOOL)isXcode13OrGreater
+{
+  return [FBXcodeConfiguration.xcodeVersionNumber compare:[NSDecimalNumber decimalNumberWithString:@"13.0"]] != NSOrderedAscending;
+}
+
 + (FBBundleDescriptor *)simulatorApp
 {
   NSError *error = nil;


### PR DESCRIPTION
## Motivation

Having Xcode13 support for idb_companion is quite essential, since it is the only version that can be used on macOS Monterey and most of the people will sooner or later migrate to this stack. Moreover there were some performance and stability improvements for the tool.

This implementation relies on newly introduced `xcrun xctrace record` API. More info [here](https://developer.apple.com/documentation/xcode-release-notes/xcode-13-release-notes)

The Xcode12< implementation should work as previously, since no changes were introduced there. 

Related issue #754 

## Test Plan

- have verified that all possible `idb instruments` commands work as previously, the **.trace** file is received and state of the process is changing correctly.

