### PR TITLE
make announcementBarContent change style (mobile)

### DIFF
--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -65,13 +65,13 @@ div[class^="announcementBarContent"] a:hover {
 }
 
 @media only screen and (max-width: 768px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 18px;
   }
 }
 
 @media only screen and (max-width: 500px) {
-  .announcement {
+  div[class^="announcementBarContent"] {
     font-size: 15px;
     line-height: 22px;
     padding: 6px 30px;


### PR DESCRIPTION
# Problem
![fdb](https://user-images.githubusercontent.com/78584173/166885723-8081e9c7-886c-4b56-8675-cac444dfe1ee.png)

Banner does not change style according to screen width.

# Code
The actual bannner class is `.announcementBarContent_KsVm` and `.announcement` does not select the banner.
Instead, `div[class^="announcementBarContent"]` changes the style of the banenr content.

