### PR TITLE
Adding in arm64e architecture constant.

### DIFF
--- a/FBControlCore/Utility/FBArchitecture.h
+++ b/FBControlCore/Utility/FBArchitecture.h
@@ -19,5 +19,6 @@ extern FBArchitecture const FBArchitectureX86_64;
 extern FBArchitecture const FBArchitectureArmv7;
 extern FBArchitecture const FBArchitectureArmv7s;
 extern FBArchitecture const FBArchitectureArm64;
+extern FBArchitecture const FBArchitectureArm64e;
 
 NS_ASSUME_NONNULL_END

--- a/FBControlCore/Utility/FBArchitecture.m
+++ b/FBControlCore/Utility/FBArchitecture.m
@@ -12,3 +12,4 @@ FBArchitecture const FBArchitectureX86_64 = @"x86_64";
 FBArchitecture const FBArchitectureArmv7 = @"armv7";
 FBArchitecture const FBArchitectureArmv7s = @"armv7s";
 FBArchitecture const FBArchitectureArm64 = @"arm64";
+FBArchitecture const FBArchitectureArm64e = @"arm64e";


### PR DESCRIPTION
Adding a missing constant from the FBArchitecture type.
