### PR TITLE
Add missing iOS, tvOS and watchOS versions

### DIFF
--- a/FBControlCore/Configuration/FBiOSTargetConfiguration.m
+++ b/FBControlCore/Configuration/FBiOSTargetConfiguration.m
@@ -127,6 +127,22 @@ FBOSVersionName const FBOSVersionNameiOS_14_2 = @"iOS 14.2";
 FBOSVersionName const FBOSVersionNameiOS_14_3 = @"iOS 14.3";
 FBOSVersionName const FBOSVersionNameiOS_14_4 = @"iOS 14.4";
 FBOSVersionName const FBOSVersionNameiOS_14_5 = @"iOS 14.5";
+FBOSVersionName const FBOSVersionNameiOS_14_6 = @"iOS 14.6";
+FBOSVersionName const FBOSVersionNameiOS_14_7 = @"iOS 14.7";
+FBOSVersionName const FBOSVersionNameiOS_14_8 = @"iOS 14.8";
+FBOSVersionName const FBOSVersionNameiOS_15_0 = @"iOS 15.0";
+FBOSVersionName const FBOSVersionNameiOS_15_1 = @"iOS 15.1";
+FBOSVersionName const FBOSVersionNameiOS_15_2 = @"iOS 15.2";
+FBOSVersionName const FBOSVersionNameiOS_15_3 = @"iOS 15.3";
+FBOSVersionName const FBOSVersionNameiOS_15_4 = @"iOS 15.4";
+FBOSVersionName const FBOSVersionNameiOS_15_5 = @"iOS 15.5";
+FBOSVersionName const FBOSVersionNameiOS_15_6 = @"iOS 15.6";
+FBOSVersionName const FBOSVersionNameiOS_15_7 = @"iOS 15.7";
+FBOSVersionName const FBOSVersionNameiOS_16_0 = @"iOS 16.0";
+FBOSVersionName const FBOSVersionNameiOS_16_1 = @"iOS 16.1";
+FBOSVersionName const FBOSVersionNameiOS_16_2 = @"iOS 16.2";
+FBOSVersionName const FBOSVersionNameiOS_16_3 = @"iOS 16.3";
+FBOSVersionName const FBOSVersionNameiOS_16_4 = @"iOS 16.4";
 FBOSVersionName const FBOSVersionNametvOS_9_0 = @"tvOS 9.0";
 FBOSVersionName const FBOSVersionNametvOS_9_1 = @"tvOS 9.1";
 FBOSVersionName const FBOSVersionNametvOS_9_2 = @"tvOS 9.2";
@@ -151,6 +167,20 @@ FBOSVersionName const FBOSVersionNametvOS_14_1 = @"tvOS 14.1";
 FBOSVersionName const FBOSVersionNametvOS_14_2 = @"tvOS 14.2";
 FBOSVersionName const FBOSVersionNametvOS_14_3 = @"tvOS 14.3";
 FBOSVersionName const FBOSVersionNametvOS_14_5 = @"tvOS 14.5";
+FBOSVersionName const FBOSVersionNametvOS_14_6 = @"tvOS 14.6";
+FBOSVersionName const FBOSVersionNametvOS_14_7 = @"tvOS 14.7";
+FBOSVersionName const FBOSVersionNametvOS_15_0 = @"tvOS 15.0";
+FBOSVersionName const FBOSVersionNametvOS_15_1 = @"tvOS 15.1";
+FBOSVersionName const FBOSVersionNametvOS_15_2 = @"tvOS 15.2";
+FBOSVersionName const FBOSVersionNametvOS_15_3 = @"tvOS 15.3";
+FBOSVersionName const FBOSVersionNametvOS_15_4 = @"tvOS 15.4";
+FBOSVersionName const FBOSVersionNametvOS_15_5 = @"tvOS 15.5";
+FBOSVersionName const FBOSVersionNametvOS_15_6 = @"tvOS 15.6";
+FBOSVersionName const FBOSVersionNametvOS_16_0 = @"tvOS 16.0";
+FBOSVersionName const FBOSVersionNametvOS_16_1 = @"tvOS 16.1";
+FBOSVersionName const FBOSVersionNametvOS_16_2 = @"tvOS 16.2";
+FBOSVersionName const FBOSVersionNametvOS_16_3 = @"tvOS 16.3";
+FBOSVersionName const FBOSVersionNametvOS_16_4 = @"tvOS 16.4";
 FBOSVersionName const FBOSVersionNamewatchOS_2_0 = @"watchOS 2.0";
 FBOSVersionName const FBOSVersionNamewatchOS_2_1 = @"watchOS 2.1";
 FBOSVersionName const FBOSVersionNamewatchOS_2_2 = @"watchOS 2.2";
@@ -171,6 +201,14 @@ FBOSVersionName const FBOSVersionNamewatchOS_7_0 = @"watchOS 7.0";
 FBOSVersionName const FBOSVersionNamewatchOS_7_1 = @"watchOS 7.1";
 FBOSVersionName const FBOSVersionNamewatchOS_7_2 = @"watchOS 7.2";
 FBOSVersionName const FBOSVersionNamewatchOS_7_4 = @"watchOS 7.4";
+FBOSVersionName const FBOSVersionNamewatchOS_7_5 = @"watchOS 7.5";
+FBOSVersionName const FBOSVersionNamewatchOS_7_6 = @"watchOS 7.6";
+FBOSVersionName const FBOSVersionNamewatchOS_8_0 = @"watchOS 8.0";
+FBOSVersionName const FBOSVersionNamewatchOS_8_1 = @"watchOS 8.1";
+FBOSVersionName const FBOSVersionNamewatchOS_9_0 = @"watchOS 9.0";
+FBOSVersionName const FBOSVersionNamewatchOS_9_1 = @"watchOS 9.1";
+FBOSVersionName const FBOSVersionNamewatchOS_9_2 = @"watchOS 9.2";
+FBOSVersionName const FBOSVersionNamewatchOS_9_3 = @"watchOS 9.3";
 
 FBOSVersionName const FBOSVersionNamemac = @"macOS";
 
@@ -567,6 +605,22 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_3],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_4],
       [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_5],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_6],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_7],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_14_8],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_0],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_1],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_2],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_3],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_4],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_5],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_6],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_15_7],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_16_0],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_16_1],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_16_2],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_16_3],
+      [FBOSVersion iOSWithName:FBOSVersionNameiOS_16_4],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_0],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_1],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_9_2],
@@ -591,6 +645,20 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_14_2],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_14_3],
       [FBOSVersion tvOSWithName:FBOSVersionNametvOS_14_5],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_14_6],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_14_7],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_0],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_1],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_2],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_3],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_4],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_5],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_15_6],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_16_0],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_16_1],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_16_2],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_16_3],
+      [FBOSVersion tvOSWithName:FBOSVersionNametvOS_16_4],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_0],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_1],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_2_2],
@@ -611,6 +679,14 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_1],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_2],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_4],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_5],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_6],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_8_0],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_8_1],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_9_0],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_9_1],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_9_2],
+      [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_9_3],
       [FBOSVersion macOSWithName:FBOSVersionNamemac],
     ];
   });


### PR DESCRIPTION
## Motivation

Display correct OS versions when listing simulators.

## Test Plan

`idb_companion --list 1` now returns correct os_version for iOS 15.4 Simulators:

{"model":"iPhone 12","os_version":"iOS 16.4","udid":"66C4D576-500A-4CE1-9AF0-3AAD17BE249D","architecture":"x86_64","type":"Simulator","name":"15_4_iPhone12","state":"Shutdown"}

{"model":"iPhone 12","os_version":"iOS 16.4","udid":"4173C584-9BD5-47F6-95C4-7BBEE1972D52","architecture":"x86_64","type":"Simulator","name":"16_4_iPhone12","state":"Shutdown"}


Prior to this change, the default (latest == 16.4) version was returned.

## Related PRs

https://github.com/facebook/idb/pull/656
