### PR TITLE
To fix "The best match 11.0 is not suitable for 0.0" 

### DIFF
--- a/FBDeviceControl/Management/FBDevice.m
+++ b/FBDeviceControl/Management/FBDevice.m
@@ -199,7 +199,7 @@
   if (!_osVersion || overwrite) {
     _osVersion = targetInfo.osVersion;
   }
-  if (_productVersion || overwrite) {
+  if (!_productVersion || overwrite) {
     _productVersion = targetInfo.productVersion;
   }
   if (!_targetType || overwrite) {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

We operate an automated test farm of around 40 iOS devices.  We have struggled with idb trying to load the Developer Disk Image for iOS V0.0 therefore failing with the error text "The best match /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/11.0/DeveloperDiskImage.dmg: 11.0 is not suitable for 0.0".

This only seemed to occur when a large number of device are connected to the system (Mac mini M1) with some devices working and others not this being largely dependent on the order that the devices were connected to the host.

This seems to be a simple typo causing the value of _productVersion to be overwritten by all calls to cacheValuesFromInfo.  The value is correctly set initially, but sometimes a later call to the function is made which overwrites it with 'undefined'.  This value is later used to derive the target version to choose the developer disk image.  

I have commented on issue #804 to which this may relate.

## Test Plan

We have a farm of all currently supported iOS devices. Before the fix ~30-50% of the devices would exhibit this issue.  After the fix, none of the devices exhibit this issue. I have attached a picture of a bit of the farm for context.

We have a test script to run through all the devices running our app on each of them and recording any errors. There are none relating to the issue after the fix compared to failures on all test runs prior.

To replicate this:

Connect 16+ different iOS devices to host and loop over all the devices connected running in turn:
idb connect --udid xxxxxxxx-xxxxxxxxxxxxxxx
idb launch my.app.undertest
idb terminate my.app.undertest
idb disconnect

On successful test should be no occurrence of the error : 

"/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/DeviceSupport/11.0/DeveloperDiskImage.dmg: 11.0 is not suitable for 0.0".

We are running a USB 2.0 hub tree with 48 USB connections hosted by a Mac Mini M1.  All devices are different in our test fixture.

The problem starts to occur in our set up occurs if more than ~8 devices are connected but that is not entirely consistent. An individual 16 port hub (internally 5 x 4 port hubs) shows this problem when all ports are used.

![IMG_9557](https://github.com/facebook/idb/assets/99685354/7f16c4c0-aca5-4a77-a764-44a0b2cbfa30)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)

