### PR TITLE
Add Xcode to requirements listed in installation.mdx

### DIFF
--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -16,7 +16,13 @@ brew tap facebook/fb
 brew install idb-companion
 ```
 
-Note: Instructions on how to install brew can be found [here](https://brew.sh)
+Notes: 
+
+1. Instructions on how to install brew can be found [here](https://brew.sh)
+
+2. A full installation of Xcode.app 13.0 is required to compile idb-companion.
+Installing just the Command Line Tools is not sufficient.
+Xcode can be installed from the App Store.
 
 ### idb client
 


### PR DESCRIPTION
When I ran `brew install idb-companion` , I was asked to install Xcode. Which is pretty serious business (in terms of waiting times) so I am adding this to the install instructions.

```shell
% brew install idb-companion
idb-companion: A full installation of Xcode.app 13.0 is required to compile
this software. Installing just the Command Line Tools is not sufficient.

Xcode can be installed from the App Store.
Error: idb-companion: An unsatisfied requirement failed this build.
```

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

(Write your motivation here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/facebook/idb, and link to your PR here.)
