### PR TITLE
Fix get_default_companion_path for Apple Silicon

### DIFF
--- a/idb/cli/main.py
+++ b/idb/cli/main.py
@@ -118,7 +118,13 @@ logger: logging.Logger = logging.getLogger()
 def get_default_companion_path() -> Optional[str]:
     if sys.platform != "darwin":
         return None
-    return shutil.which("idb_companion") or "/usr/local/bin/idb_companion"
+    for path in (
+        shutil.which("idb_companion"),
+        "/opt/homebrew/bin/idb_companion",
+        "/usr/local/bin/idb_companion",
+    ):
+        if path and os.path.exists(path):
+            return path
 
 
 async def gen_main(cmd_input: Optional[List[str]] = None) -> int:


### PR DESCRIPTION
On Apple Silicon systems, homebrew installs into /opt/homebrew instead of /usr/local. Update get_default_companion_path to look for idb_companion in both /opt/homebrew/bin and /usr/local/bin (if it is not already in PATH)

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

On newer macOS hardware, homebrew installs into /opt/homebrew by default.

1. Most users probably install idb via homebrew
2. /opt/homebrew/bin is not in the default PATH that apps see when launched from Finder
3. So when you launch (e.g.) Flipper from Finder it will log an error like "/usr/local/bin/idb_companion not found" and idb functionality won't work.
4. Therefore, this change makes get_default_companion_path look for idb_companion in /opt/homebrew/bin then /usr/local/bin (if it's not already in PATH) to cover all the likely configurations.

## Test Plan

With this change, Flipper works correctly
