### PR TITLE
Add visionOS as a known platform.

### DIFF
--- a/FBControlCore/Configuration/FBiOSTargetConfiguration.h
+++ b/FBControlCore/Configuration/FBiOSTargetConfiguration.h
@@ -22,6 +22,7 @@ typedef NS_ENUM(NSUInteger, FBControlCoreProductFamily) {
   FBControlCoreProductFamilyAppleTV = 3,
   FBControlCoreProductFamilyAppleWatch = 4,
   FBControlCoreProductFamilyMac = 5,
+  FBControlCoreProductFamilyVision = 7,
 };
 
 /**
@@ -108,6 +109,7 @@ extern FBDeviceModel const FBDeviceModelAppleWatchSeries5_40mm;
 extern FBDeviceModel const FBDeviceModelAppleWatchSeries5_44mm;
 extern FBDeviceModel const FBDeviceModelAppleWatchSeries6_40mm;
 extern FBDeviceModel const FBDeviceModelAppleWatchSeries6_44mm;
+extern FBDeviceModel const FBDeviceModelAppleVisionPro;
 
 /**
  OS Versions Name Enumeration.
@@ -188,6 +190,7 @@ extern FBOSVersionName const FBOSVersionNamewatchOS_6_1;
 extern FBOSVersionName const FBOSVersionNamewatchOS_6_2;
 extern FBOSVersionName const FBOSVersionNamewatchOS_7_0;
 extern FBOSVersionName const FBOSVersionNamewatchOS_7_1;
+extern FBOSVersionName const FBOSVersionNamexrOS_1_0;
 extern FBOSVersionName const FBOSVersionNamemac;
 
 #pragma mark Screen

--- a/FBControlCore/Configuration/FBiOSTargetConfiguration.m
+++ b/FBControlCore/Configuration/FBiOSTargetConfiguration.m
@@ -93,6 +93,7 @@ FBDeviceModel const FBDeviceModelAppleWatchSeries5_40mm = @"Apple Watch Series 5
 FBDeviceModel const FBDeviceModelAppleWatchSeries5_44mm = @"Apple Watch Series 5 - 44mm";
 FBDeviceModel const FBDeviceModelAppleWatchSeries6_40mm = @"Apple Watch Series 6 - 40mm";
 FBDeviceModel const FBDeviceModelAppleWatchSeries6_44mm = @"Apple Watch Series 6 - 44mm";
+FBDeviceModel const FBDeviceModelAppleVisionPro = @"Apple Vision Pro";
 
 FBOSVersionName const FBOSVersionNameiOS_7_1 = @"iOS 7.1";
 FBOSVersionName const FBOSVersionNameiOS_8_0 = @"iOS 8.0";
@@ -179,6 +180,7 @@ FBOSVersionName const FBOSVersionNamewatchOS_7_0 = @"watchOS 7.0";
 FBOSVersionName const FBOSVersionNamewatchOS_7_1 = @"watchOS 7.1";
 FBOSVersionName const FBOSVersionNamewatchOS_7_2 = @"watchOS 7.2";
 FBOSVersionName const FBOSVersionNamewatchOS_7_4 = @"watchOS 7.4";
+FBOSVersionName const FBOSVersionNamexrOS_1_0 = @"xrOS 1.0";
 
 FBOSVersionName const FBOSVersionNamemac = @"macOS";
 
@@ -299,6 +301,12 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
 + (instancetype)watchWithModel:(FBDeviceModel)model productTypes:(NSArray<NSString *> *)productTypes deviceArchitecture:(FBArchitecture)deviceArchitecture
 {
   return [[self alloc] initWithModel:model productTypes:[NSSet setWithArray:productTypes] deviceArchitecture:deviceArchitecture family:FBControlCoreProductFamilyAppleWatch];
+}
+
++ (instancetype)visionWithModel:(FBDeviceModel)model
+                     productTypes:(NSArray<NSString *> *)productTypes
+               deviceArchitecture:(FBArchitecture)deviceArchitecture {
+  return [[self alloc] initWithModel:model productTypes:[NSSet setWithArray:productTypes] deviceArchitecture:deviceArchitecture family:FBControlCoreProductFamilyVision];
 }
 
 + (instancetype)genericWithModel:(NSString *)model
@@ -428,6 +436,10 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
   return [[self alloc] initWithName:name families:[NSSet setWithObject:@(FBControlCoreProductFamilyAppleWatch)]];
 }
 
++ (instancetype)xrOSWithName:(FBOSVersionName)name {
+  return [[self alloc] initWithName:name families:[NSSet setWithObject:@(FBControlCoreProductFamilyVision)]];
+}
+
 + (instancetype)macOSWithName:(FBOSVersionName)name
 {
   return [[self alloc] initWithName:name families:[NSSet setWithObject:@(FBControlCoreProductFamilyMac)]];
@@ -528,7 +540,7 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
       [FBDeviceType watchWithModel:FBDeviceModelAppleWatchSeries5_44mm productTypes:@[@"Watch5,2", @"Watch5,4"] deviceArchitecture:FBArchitectureArm64],
       [FBDeviceType watchWithModel:FBDeviceModelAppleWatchSeries6_40mm productTypes:@[@"Watch6,1", @"Watch6,3"] deviceArchitecture:FBArchitectureArm64],
       [FBDeviceType watchWithModel:FBDeviceModelAppleWatchSeries6_44mm productTypes:@[@"Watch6,2", @"Watch6,4"] deviceArchitecture:FBArchitectureArm64],
-
+      [FBDeviceType visionWithModel:FBDeviceModelAppleVisionPro productTypes:@[ @"RealityDevice14,1" ] deviceArchitecture:FBArchitectureArm64],
     ];
   });
   return deviceConfigurations;
@@ -626,6 +638,7 @@ FBOSVersionName const FBOSVersionNamemac = @"macOS";
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_1],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_2],
       [FBOSVersion tvOSWithName:FBOSVersionNamewatchOS_7_4],
+      [FBOSVersion xrOSWithName:FBOSVersionNamexrOS_1_0],
       [FBOSVersion macOSWithName:FBOSVersionNamemac],
     ];
   });

--- a/FBDeviceControl/Management/FBAMDevice.m
+++ b/FBDeviceControl/Management/FBAMDevice.m
@@ -277,6 +277,7 @@
   NSDictionary<NSString *, NSString *> *deviceClassOSPrefixMapping = @{
     @"iPhone" : @"iOS",
     @"iPad" : @"iOS",
+    @"RealityDevice" : @"xrOS",
   };
   NSString *osPrefix = deviceClassOSPrefixMapping[deviceClass];
   if (!osPrefix) {

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -209,6 +209,8 @@ static NSString *const DefaultDeviceSet = @"~/Library/Developer/CoreSimulator/De
       return FBControlCoreProductFamilyAppleTV;
     case 4:
       return FBControlCoreProductFamilyAppleWatch;
+    case 7:
+      return FBControlCoreProductFamilyVision;
     default:
       return FBControlCoreProductFamilyUnknown;
   }


### PR DESCRIPTION
This change allows identifying Apple Reality Pro devices as visionOS devices when working with FBDevice/FBSimulator objects rather than generic unknown products.