### PR TITLE
upgrade grpc-swift to 1.23.0

### DIFF
--- a/idb_companion.xcodeproj/project.pbxproj
+++ b/idb_companion.xcodeproj/project.pbxproj
@@ -959,7 +959,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "cd ${BUILD_DIR}\npwd\ncd ${BUILD_DIR%Build/*}SourcePackages/checkouts/grpc-swift\nmake plugins\npwd\n";
+			shellScript = "cd ${BUILD_DIR}\npwd\ncd ${BUILD_DIR%Build/*}SourcePackages/checkouts/grpc-swift\nswift build -c release --product protoc-gen-swift\nswift build -c release --product protoc-gen-grpc-swift\npwd\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -1589,7 +1589,7 @@
 			repositoryURL = "https://github.com/grpc/grpc-swift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 1.10.0;
+				version = 1.23.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
## Motivation

Referring to the following issue, the new version of xcode seems to be unable to support the compilation of the old version of grpc-swift.

This PR fixes this problem so that idb can be compiled and used normally.

https://github.com/facebook/idb/issues/860#issuecomment-2098427760
https://github.com/facebook/idb/issues/860#issuecomment-2099714573

## Test Plan

Run tests related to grpc-swift and idb.

## Related PRs

Unnecessary.
