### PR TITLE
Updating run command to dynamically create bundles based on file path

### DIFF
--- a/CompanionLib/Request/FBXCTestRunRequest.h
+++ b/CompanionLib/Request/FBXCTestRunRequest.h
@@ -40,6 +40,22 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)logicTestWithTestBundleID:(NSString *)testBundleID environment:(NSDictionary<NSString *, NSString *> *)environment arguments:(NSArray<NSString *> *)arguments testsToRun:(nullable NSSet<NSString *> *)testsToRun testsToSkip:(NSSet<NSString *> *)testsToSkip testTimeout:(NSNumber *)testTimeout reportActivities:(BOOL)reportActivities reportAttachments:(BOOL)reportAttachments coverageRequest:(FBCodeCoverageRequest *)coverageRequest collectLogs:(BOOL)collectLogs waitForDebugger:(BOOL)waitForDebugger collectResultBundle:(BOOL)collectResultBundle;
 
 /**
+ Initializer for Logic Tests from a test path.
+
+ @param testPath the path of the .xctest or .xctestrun file.
+ @param environment environment for the logic test process.
+ @param arguments arguments for the logic test process.
+ @param testsToRun the tests to run.
+ @param testsToSkip the tests to skip
+ @param testTimeout the timeout for the entire execution, nil if no timeout should be applied.
+ @param reportActivities if set activities and their data will be reported
+ @param coverageRequest information about llvm code coverage collection
+ @param waitForDebugger a boolean describing whether the tests should stop after Run and wait for a debugger to be attached.
+ @return an FBXCTestRunRequest instance.
+ */
++ (instancetype)logicTestWithTestPath:(NSURL *)testPath environment:(NSDictionary<NSString *, NSString *> *)environment arguments:(NSArray<NSString *> *)arguments testsToRun:(nullable NSSet<NSString *> *)testsToRun testsToSkip:(NSSet<NSString *> *)testsToSkip testTimeout:(NSNumber *)testTimeout reportActivities:(BOOL)reportActivities reportAttachments:(BOOL)reportAttachments coverageRequest:(FBCodeCoverageRequest *)coverageRequest collectLogs:(BOOL)collectLogs waitForDebugger:(BOOL)waitForDebugger collectResultBundle:(BOOL)collectResultBundle;
+
+/**
 The Initializer for App Tests.
 
  @param testBundleID the bundle id of the test to run.
@@ -87,6 +103,11 @@ The Initializer for UI Tests.
  The Bundle ID of the Test bundle.
  */
 @property (nonatomic, copy, readonly) NSString *testBundleID;
+
+/**
+ The path of the .xctest or .xctestrun file.
+ */
+ @property (nonatomic, copy, readonly) NSURL *testPath;
 
 /**
  The Bundle ID of the Test Host, if relevant.

--- a/CompanionLib/Utility/FBIDBStorageManager.h
+++ b/CompanionLib/Utility/FBIDBStorageManager.h
@@ -214,6 +214,14 @@ extern NSString *const IdbFrameworksFolder;
  */
 - (nullable id<FBXCTestDescriptor>)testDescriptorWithID:(NSString *)bundleId error:(NSError **)error;
 
+/**
+ Get test run descriptors from xctestrun file.
+
+ @param xctestrunURL URL of xctestrun file
+ @return test descriptor of the test
+ */
+- (nullable NSArray<id<FBXCTestDescriptor>> *)getXCTestRunDescriptorsFromURL:(NSURL *)xctestrunURL error:(NSError **)error;
+
 @end
 
 /**


### PR DESCRIPTION
Summary:
## Context

The installation step for XCTest bundles creates symlinks to the test bundle source on the host machine in a static directory (`idb-test-bundles`), or copies the files from the source location to that directory. This is not necessary for XCTest if the bundle lives in the host machine, as the test bundle is injected as a dylib.

By removing these symlinks, we get rid of some additional complexity, and remove the risk of leaving broken symlinks around on the host device. These old/broken symlinks create noise in test logs, which make them hard to read.

## This diff
- Enables a test request API which takes a testPath, which points directly to the original test bundle location.
- Creates a bundle & artifcat objects in memory on run, as opposed to finding them on disk in idb-test-bundles.
## Future Considerations
- Possible enable code signing in the test run creation request. The install step, by default, code signs the test bundles.
- We could create a CommandExecutor that is not dependent on an instance of the StorageManager class. The initialization of the StorageManager creates a static directory that we no longer need to exist if we skip the installation step. This is a pretty big undertaking, and this diff removes the symlinks which have been creating

Differential Revision: D66895643


