### PR TITLE
Adding file path APIs for "list"

### DIFF
--- a/CompanionLib/FBIDBCommandExecutor.h
+++ b/CompanionLib/FBIDBCommandExecutor.h
@@ -292,6 +292,13 @@ This enables the permission popup the first time we open a deeplink
 - (FBFuture<NSArray<NSString *> *> *)list_tests_in_bundle:(NSString *)bundleID with_app:(nullable NSString *)appPath;
 
 /**
+ List the tests in an installed bundle using the file path of the bundle.
+
+ @return a Future that resolves with names of tests in the bundle.
+ */
+- (FBFuture<NSArray<NSString *> *> *)list_tests_in_bundle_file_path:(NSURL *)bundlePath;
+
+/**
  Uninstall an application
 
  @param bundleID bundle id of the application to uninstall


### PR DESCRIPTION
Summary:
## Context

`idb list` produces an abundance of "Bundle not found at path" errors, as it attempts to read test descriptors from a static symlink directory that is not automatically cleaned. This leads to messy error logs, as old symlinks (that have had their source file removed) cannot be loaded properly.

## This diff
- Adds file path APIs for `list` so that we load the descriptors from the source file, as opposed to the symlink proxy.

Differential Revision: D67464085


