### PR TITLE
allow specifying work/async queues via configuration

### DIFF
--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.h
@@ -27,6 +27,18 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)configurationWithDeviceSetPath:(nullable NSString *)deviceSetPath logger:(nullable id<FBControlCoreLogger>)logger reporter:(nullable id<FBEventReporter>)reporter;
 
 /**
+ Creates and returns a new Configuration with the provided parameters.
+
+ @param deviceSetPath the Path to the Device Set. If nil, the default Device Set will be used.
+ @param logger the logger to use.
+ @param reporter the reporter to report to.
+ @param workQueue the queue to perform work on.
+ @param asyncQueue the queue to invoke async handlers on.
+ @return a new Configuration Object with the arguments applied.
+ */
++ (instancetype)configurationWithDeviceSetPath:(nullable NSString *)deviceSetPath logger:(nullable id<FBControlCoreLogger>)logger reporter:(nullable id<FBEventReporter>)reporter workQueue:(nullable dispatch_queue_t)workQueue asyncQueue:(nullable dispatch_queue_t)asyncQueue;
+
+/**
  The Location of the SimDeviceSet. If no path is provided, the default device set will be used.
  */
 @property (nonatomic, copy, nullable, readonly) NSString *deviceSetPath;
@@ -40,6 +52,17 @@ NS_ASSUME_NONNULL_BEGIN
  The Event Reporter to use for reporting events.
  */
 @property (nonatomic, strong, nullable, readonly) id<FBEventReporter> reporter;
+
+/**
+ The dispatch queue to use as work queue
+ */
+@property (nonatomic, strong, nullable, readonly) dispatch_queue_t workQueue;
+
+/**
+ The dispatch queue to use as async queue
+ */
+@property (nonatomic, strong, nullable, readonly) dispatch_queue_t asyncQueue;
+
 
 @end
 

--- a/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
+++ b/FBSimulatorControl/Configuration/FBSimulatorControlConfiguration.m
@@ -35,10 +35,33 @@
 
 + (instancetype)configurationWithDeviceSetPath:(NSString *)deviceSetPath logger:(id<FBControlCoreLogger>)logger reporter:(id<FBEventReporter>)reporter
 {
-  return [[self alloc] initWithDeviceSetPath:deviceSetPath logger:(logger ?: FBControlCoreGlobalConfiguration.defaultLogger) reporter:reporter];
+  return [[self alloc] initWithDeviceSetPath:deviceSetPath
+                                      logger:(logger ?: FBControlCoreGlobalConfiguration.defaultLogger)
+                                    reporter:reporter
+                                   workQueue:nil
+                                  asyncQueue:nil
+  ];
 }
 
-- (instancetype)initWithDeviceSetPath:(NSString *)deviceSetPath logger:(id<FBControlCoreLogger>)logger reporter:(id<FBEventReporter>)reporter
++ (instancetype)configurationWithDeviceSetPath:(nullable NSString *)deviceSetPath
+                                        logger:(id<FBControlCoreLogger>)logger
+                                      reporter:(id<FBEventReporter>)reporter
+                                     workQueue:(dispatch_queue_t)workQueue
+                                    asyncQueue:(dispatch_queue_t)asyncQueue
+{
+    return [[self alloc] initWithDeviceSetPath:deviceSetPath
+                                        logger:(logger ?: FBControlCoreGlobalConfiguration.defaultLogger)
+                                      reporter:reporter
+                                     workQueue:workQueue
+                                    asyncQueue:asyncQueue
+    ];
+}
+
+- (instancetype)initWithDeviceSetPath:(NSString *)deviceSetPath
+                               logger:(id<FBControlCoreLogger>)logger
+                             reporter:(id<FBEventReporter>)reporter
+                            workQueue:(dispatch_queue_t)workQueue
+                           asyncQueue:(dispatch_queue_t)asyncQueue
 {
   self = [super init];
   if (!self) {
@@ -48,6 +71,8 @@
   _deviceSetPath = deviceSetPath;
   _logger = logger;
   _reporter = reporter;
+  _workQueue = workQueue;
+  _asyncQueue = asyncQueue;
 
   return self;
 }

--- a/FBSimulatorControl/Management/FBSimulator.m
+++ b/FBSimulatorControl/Management/FBSimulator.m
@@ -166,12 +166,20 @@ static NSString *const DefaultDeviceSet = @"~/Library/Developer/CoreSimulator/De
 
 - (dispatch_queue_t)workQueue
 {
-  return dispatch_get_main_queue();
+  dispatch_queue_t workQueue = _set.workQueue;
+  if (workQueue == nil) {
+    workQueue = dispatch_get_main_queue();
+  }
+  return workQueue;
 }
 
 - (dispatch_queue_t)asyncQueue
 {
-  return dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  dispatch_queue_t asyncQueue = _set.asyncQueue;
+  if (asyncQueue == nil) {
+    asyncQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0);
+  }
+  return asyncQueue;
 }
 
 - (NSDictionary<NSString *, id> *)extendedInformation

--- a/FBSimulatorControl/Management/FBSimulatorSet.m
+++ b/FBSimulatorControl/Management/FBSimulatorSet.m
@@ -57,8 +57,8 @@
   _delegate = delegate;
   _logger = logger;
   _reporter = reporter;
-  _workQueue = dispatch_get_main_queue();
-  _asyncQueue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
+  _workQueue = configuration.workQueue ? configuration.workQueue : dispatch_get_main_queue();
+  _asyncQueue = configuration.asyncQueue ? configuration.asyncQueue : dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
 
   _allSimulators = @[];
   _inflationStrategy = [FBSimulatorInflationStrategy strategyForSet:self];


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to `idb` here: https://github.com/facebook/idb/blob/main/.github/CONTRIBUTING.md

Happy contributing!

-->

## Motivation

I need to run idb in a node native addon thus there is nothing to drive the main queue which is used under the hood. This PR seems to allow me to boot a device and receive the callbacks by providing  custom  async/work queues via `FBSimulatorControlConfiguration`. I tried to make this an opt in behaviour - the new properties are default `nil` and have a designated initializer and internally the work/async queues use the old values if these configuration values are not specified.

## Test Plan

Testing is something i wanted some feedback on. So obviously:

1) using the existing configuration should not change any tests since as i mentioned this should be opt in
2) tests also use `dispatch_get_main_queue()` which would then need to be adjusted - as in the tests should then use a given queue (most likely each test should be run with main and with a custom queue?), provide it to the frameworks via the configuration and expect everything to work. Is that the route that should be taken here?
