### PR TITLE
Update Docusaurus banner to support Palestine and address humanitarian visibility

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -17,7 +17,7 @@ module.exports = {
     announcementBar: {
       id: 'support_ukraine',
       content:
-        'Support Ukraine 🇺🇦 <a target="_blank" rel="noopener noreferrer" href="https://opensource.fb.com/support-ukraine"> Help Provide Humanitarian Aid to Ukraine</a>.',
+        'Support Palestine 🇵🇸 <a target="_blank" rel="noopener noreferrer" href="https://www.facebook.com/fundraisers/explore/search/fundraisers/?q=palestine"> Help Provide Humanitarian Aid to Palestine</a>.',
       backgroundColor: '#20232a',
       textColor: '#fff',
       isCloseable: false,


### PR DESCRIPTION
## Motivation
Update the Docusaurus site banner to highlight humanitarian support for Palestine. While conflicts like the war in Ukraine receive widespread attention, Palestine is facing severe humanitarian challenges that are often overlooked—addressing this double standard helps provide visibility and aid where it’s urgently needed.

## Test Plan

1.	Ran npm start locally to verify the banner renders correctly.
2.	Confirmed that the new message reads:
	```Support Palestine 🇵🇸 Help Provide Humanitarian Aid to Palestine```
3. Clicked the link and verified it opens the correct Facebook fundraiser page in a new tab.
4. Verified that the background color (#20232a) is unchanged and the banner layout is consistent with the original design.
	

	

## Related PRs
None. This change only updates site content; no functionality changes in the IDB codebase.
