### PR TITLE
Fix describe remote web content discovery and add regression tests

### DIFF
--- a/CompanionLib/FBIDBCommandExecutor.m
+++ b/CompanionLib/FBIDBCommandExecutor.m
@@ -155,6 +155,8 @@ FBFileContainerKind const FBFileContainerKindFramework = @"framework";
       FBAccessibilityRequestOptions *options = [FBAccessibilityRequestOptions defaultOptions];
       options.nestedFormat = nestedFormat;
       options.enableLogging = YES;
+      options.collectFrameCoverage = YES;
+      options.remoteContentOptions = [FBAccessibilityRemoteContentOptions defaultOptions];
 
       if (value) {
         return [commands accessibilityElementAtPoint:value.pointValue options:options];

--- a/FBSimulatorControl/Commands/FBSimulatorAccessibilityCommands.m
+++ b/FBSimulatorControl/Commands/FBSimulatorAccessibilityCommands.m
@@ -313,8 +313,10 @@ static const CGFloat kDefaultCellSize = 10.0;
 
   // Fill cells row by row using memset for efficiency
   NSUInteger fillWidth = (NSUInteger)(maxX - minX + 1);
+  NSUInteger startX = (NSUInteger)minX;
   for (NSInteger y = minY; y <= maxY; y++) {
-    memset(&_grid[y * _width + minX], 1, fillWidth);
+    NSUInteger row = (NSUInteger)y;
+    memset(&_grid[row * _width + startX], 1, fillWidth);
   }
 }
 
@@ -339,7 +341,9 @@ static const CGFloat kDefaultCellSize = 10.0;
   }
 
   // O(1) lookup in the grid array
-  return _grid[cellY * _width + cellX] != 0;
+  NSUInteger x = (NSUInteger)cellX;
+  NSUInteger y = (NSUInteger)cellY;
+  return _grid[y * _width + x] != 0;
 }
 
 - (CGFloat)coverageRatio
@@ -369,6 +373,14 @@ static const CGFloat kDefaultCellSize = 10.0;
 @implementation FBSimulatorAccessibilitySerializer
 
 static NSString *const AXPrefix = @"AX";
+
+static BOOL FBIsWebContentRole(NSString *rawRole)
+{
+  if (rawRole.length == 0) {
+    return NO;
+  }
+  return [rawRole hasPrefix:@"AXWeb"] || [rawRole hasPrefix:@"Web"];
+}
 
 + (NSArray<NSString *> *)customActionsFromElement:(AXPMacPlatformElement *)element
 {
@@ -487,7 +499,8 @@ static NSString *const FBAXDiscoveryMethodPointGrid = @"point_grid";
     }
     // Skip Application elements when calculating coverage
     BOOL isApplication = [rawRole isEqualToString:@"AXApplication"] || [rawRole isEqualToString:@"Application"];
-    if (!isApplication) {
+    BOOL isWebContentContainer = FBIsWebContentRole(rawRole);
+    if (!isApplication && !isWebContentContainer) {
       [coverageGrid markFilledWithFrame:frame];
     }
   }
@@ -656,6 +669,14 @@ static NSString *const FBAXDiscoveryMethodPointGrid = @"point_grid";
   CGRect region = CGRectIsNull(remoteOptions.region) ? screenBounds : remoteOptions.region;
   NSUInteger maxPoints = remoteOptions.maxPoints;
   NSUInteger pointCount = 0;
+  // If native traversal claims near-total coverage, we still probe covered points.
+  // This handles full-screen proxy/container elements (including some WebView wrappers)
+  // that can mask remote-process accessibility content.
+  BOOL allowCoveredPointProbing = NO;
+  if (coverageGrid) {
+    CGFloat coverageRatio = [coverageGrid coverageRatio];
+    allowCoveredPointProbing = coverageRatio >= 0.98;
+  }
 
   for (CGFloat y = stepSize; y < region.size.height - stepSize; y += stepSize) {
     for (CGFloat x = stepSize; x < region.size.width - stepSize; x += stepSize) {
@@ -667,7 +688,7 @@ static NSString *const FBAXDiscoveryMethodPointGrid = @"point_grid";
 
       // Skip points already covered by native accessibility elements.
       // This dynamically excludes toolbars, nav bars, and other covered regions.
-      if (coverageGrid && [coverageGrid isFilledAtPoint:point]) {
+      if (coverageGrid && [coverageGrid isFilledAtPoint:point] && !allowCoveredPointProbing) {
         continue;
       }
 
@@ -681,12 +702,11 @@ static NSString *const FBAXDiscoveryMethodPointGrid = @"point_grid";
       hitTranslation.bridgeDelegateToken = self.token;
       pid_t hitPid = hitTranslation.pid;
 
-      // Skip if PID was already seen in main traversal
-      if ([seenPids containsObject:@(hitPid)]) {
-        continue;
-      }
-
-      if (hitPid <= 0 || hitPid == frontmostPid) {
+      BOOL seenInMainTraversal = [seenPids containsObject:@(hitPid)];
+      // In near-full-coverage mode, allow seen/frontmost/unknown PID hits to recover
+      // hidden content that isn't surfaced in the recursive tree.
+      BOOL potentiallyHiddenContent = allowCoveredPointProbing && (seenInMainTraversal || hitPid <= 0 || hitPid == frontmostPid);
+      if (seenInMainTraversal && !allowCoveredPointProbing) {
         continue;
       }
 
@@ -696,6 +716,17 @@ static NSString *const FBAXDiscoveryMethodPointGrid = @"point_grid";
       }
 
       CGRect hitFrame = hitElement.accessibilityFrame;
+      if (potentiallyHiddenContent) {
+        // Avoid duplicating top-level full-screen proxy elements.
+        CGFloat screenArea = CGRectGetWidth(screenBounds) * CGRectGetHeight(screenBounds);
+        CGFloat hitArea = CGRectGetWidth(hitFrame) * CGRectGetHeight(hitFrame);
+        if (screenArea <= 0 || hitArea >= (screenArea * 0.98)) {
+          continue;
+        }
+      } else if (hitPid <= 0 || hitPid == frontmostPid) {
+        continue;
+      }
+
       NSValue *hitFrameValue = [NSValue valueWithRect:hitFrame];
 
       if ([discoveredFrames containsObject:hitFrameValue]) {

--- a/FBSimulatorControlTests/Utilities/AccessibilityDoubles.h
+++ b/FBSimulatorControlTests/Utilities/AccessibilityDoubles.h
@@ -82,6 +82,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (FBSimulatorControlTests_AXPTranslationObject_Double *)frontmostApplicationWithDisplayId:(int)displayId bridgeDelegateToken:(NSString *)token;
 - (FBSimulatorControlTests_AXPTranslationObject_Double *)objectAtPoint:(CGPoint)point displayId:(int)displayId bridgeDelegateToken:(NSString *)token;
 - (FBSimulatorControlTests_AXPMacPlatformElement_Double *)macPlatformElementFromTranslation:(FBSimulatorControlTests_AXPTranslationObject_Double *)translation;
+- (void)setMacPlatformElement:(nullable FBSimulatorControlTests_AXPMacPlatformElement_Double *)element
+               forTranslation:(FBSimulatorControlTests_AXPTranslationObject_Double *)translation;
+- (void)clearMacPlatformElementMappings;
 
 - (void)resetTracking;
 

--- a/FBSimulatorControlTests/Utilities/AccessibilityDoubles.m
+++ b/FBSimulatorControlTests/Utilities/AccessibilityDoubles.m
@@ -187,6 +187,9 @@
 @end
 
 @implementation FBSimulatorControlTests_AXPTranslator_Double
+{
+  NSMapTable *_macPlatformElementByTranslation;
+}
 
 - (instancetype)init
 {
@@ -196,6 +199,7 @@
   }
 
   _methodCalls = [NSMutableArray array];
+  _macPlatformElementByTranslation = [NSMapTable strongToStrongObjectsMapTable];
 
   return self;
 }
@@ -219,14 +223,33 @@
 - (FBSimulatorControlTests_AXPMacPlatformElement_Double *)macPlatformElementFromTranslation:(FBSimulatorControlTests_AXPTranslationObject_Double *)translation
 {
   [_methodCalls addObject:@"macPlatformElementFromTranslation"];
-  FBSimulatorControlTests_AXPMacPlatformElement_Double *result = self.macPlatformElementResult;
+  FBSimulatorControlTests_AXPMacPlatformElement_Double *result = [_macPlatformElementByTranslation objectForKey:translation] ?: self.macPlatformElementResult;
   result.translation = translation;
   return result;
+}
+
+- (void)setMacPlatformElement:(FBSimulatorControlTests_AXPMacPlatformElement_Double *)element
+               forTranslation:(FBSimulatorControlTests_AXPTranslationObject_Double *)translation
+{
+  if (!translation) {
+    return;
+  }
+  if (element) {
+    [_macPlatformElementByTranslation setObject:element forKey:translation];
+  } else {
+    [_macPlatformElementByTranslation removeObjectForKey:translation];
+  }
+}
+
+- (void)clearMacPlatformElementMappings
+{
+  [_macPlatformElementByTranslation removeAllObjects];
 }
 
 - (void)resetTracking
 {
   [_methodCalls removeAllObjects];
+  [_macPlatformElementByTranslation removeAllObjects];
 }
 
 @end


### PR DESCRIPTION
## Motivation

`idb ui describe` was not reliably returning accessibility elements inside embedded web content (WebView), even when those elements were present and VoiceOver-accessible.

Root causes:
- The `describe` path did not enable remote-content discovery options.
- Remote discovery could be starved when native traversal reported near-total frame coverage (common with full-screen proxy/container elements), because covered points were skipped and same/frontmost PID hits were filtered out.
- Coverage accounting included `AXWeb*` container roles, which could overstate “already covered” area and suppress remote probing.

Implemented changes:
- `CompanionLib/FBIDBCommandExecutor.m`: enabled remote discovery for describe calls by setting `collectFrameCoverage` and default `remoteContentOptions`.
- `FBSimulatorControl/Commands/FBSimulatorAccessibilityCommands.m`: excluded web container roles (`AXWeb*` / `Web*`) from base frame coverage; added near-full-coverage fallback probing (`coverage >= 0.98`); allowed seen/frontmost/unknown PID hits in that fallback path to recover hidden content; skipped near-fullscreen proxy hits to avoid duplicate wrappers; kept explicit unsigned index conversions needed for strict warning-as-error builds.
- `FBSimulatorControlTests/Utilities/AccessibilityDoubles.h` and `FBSimulatorControlTests/Utilities/AccessibilityDoubles.m`: added translation-to-element mapping support in the translator double so tests can model frontmost-tree vs hit-tested remote elements.
- `FBSimulatorControlTests/Tests/Unit/FBSimulatorAccessibilityCommandsTests.m`: added targeted regression tests:
  - `testCoverageCalculationSkipsWebContentRoleElements`
  - `testRemoteDiscoveryFindsHiddenContentWhenCoverageIsNearFull`
  - `testRemoteDiscoverySkipsFullscreenProxyInNearFullCoverageMode`
- `FBSimulatorControlTests/Tests/Unit/FBSimulatorAccessibilityCommandsTests.m`: retained test-only `int64_t` casts needed to satisfy strict sign-compare checks in this toolchain.

Compatibility:
- No gRPC interface changes.
- No CLI schema/flag changes.
- Behavior changes are scoped to accessibility describe discovery and supporting tests.

## Test Plan

1. Build tests target:
   ```bash
   xcodebuild -project FBSimulatorControl.xcodeproj -target FBSimulatorControlTests -configuration Debug -sdk macosx build
   ```

2. Run accessibility unit suite:
   ```bash
   export DYLD_FRAMEWORK_PATH=$PWD/build/Debug
   xcrun xctest -XCTest FBSimulatorControlTestCase,FBSimulatorAccessibilityCommandsTests $PWD/build/Debug/FBSimulatorControlTests.xctest
   ```
   Result: `21 tests, 0 failures` (includes all new regression tests).

3. Build companion libraries:
   ```bash
   xcodebuild -project FBSimulatorControl.xcodeproj -target CompanionLib -configuration Debug -sdk macosx build
   ```

4. Manual runtime verification on booted simulator:
   ```bash
   build/Build/Products/Debug/idb_companion --udid 78F1F8EA-CDE6-45A6-BB20-C5D40241D8E6 --grpc-port 11601 --log-level debug
   idb --companion 127.0.0.1:11601 ui describe-all --json
   ```
   Verified output includes embedded webview labels/element.

## Related PRs

None.



I accepted the CLA