### PR TITLE
Fix missing f-string prefix in lockfile error message

### DIFF
--- a/idb/common/companion_set.py
+++ b/idb/common/companion_set.py
@@ -41,7 +41,7 @@ async def _open_lockfile(filename: str) -> AsyncGenerator[None, None]:
                 yield None
             except FileExistsError:
                 if datetime.now() >= deadline:
-                    raise IdbException("Failed to open the lockfile {lock_path}")
+                    raise IdbException(f"Failed to open the lockfile {lock_path}")
                 await asyncio.sleep(retry_time)
     finally:
         if lock is not None:


### PR DESCRIPTION
## Motivation

  While investigating a lockfile timeout issue during idb companion management, I noticed the error message in _open_lockfile() prints the literal string {lock_path} instead of the actual file path:

  IdbException: Failed to open the lockfile {lock_path}

  This makes it difficult to diagnose which lockfile is stuck or what state file is involved. The cause is a missing f prefix on the string literal (companion_set.py:44).

  The rest of the codebase consistently uses f-strings for exception messages (e.g., companion.py, management.py, tar.py), so this appears to be an unintentional omission.

## Test Plan

  - Verified syntax with python3 -m py_compile idb/common/companion_set.py — passed
  - Project-wide search confirmed this is the only raise statement missing the f prefix — all 11 other similar patterns use f-strings correctly
  - Change is limited to the error message string; no logic or control flow is affected

## Related PRs

  N/A