### PR TITLE
Fix 'occured' -> 'occurred' typos in 3 files

### DIFF
--- a/FBControlCore/Utility/FBProcessStream.h
+++ b/FBControlCore/Utility/FBProcessStream.h
@@ -76,7 +76,7 @@ typedef NS_ENUM(NSUInteger, FBProcessStreamAttachmentMode) {
 @property (nonatomic, assign, readonly) ssize_t bytesTransferred;
 
 /**
- An error, if any has occured in the streaming of data to the input.
+ An error, if any has occurred in the streaming of data to the input.
  */
 @property (nonatomic, strong, nullable, readonly) NSError *streamError;
 

--- a/XCTestBootstrap/MacStrategies/FBMacDevice.m
+++ b/XCTestBootstrap/MacStrategies/FBMacDevice.m
@@ -197,7 +197,7 @@
     if (!proxyError) {
       return;
     }
-    [logger logFormat:@"Error occured during synchronousRemoteObjectProxyWithErrorHandler call: %@", proxyError.description];
+    [logger logFormat:@"Error occurred during synchronousRemoteObjectProxyWithErrorHandler call: %@", proxyError.description];
     weakSelf.connection = nil;
   }];
 

--- a/XCTestBootstrap/TestManager/FBTestBundleConnection.m
+++ b/XCTestBootstrap/TestManager/FBTestBundleConnection.m
@@ -320,7 +320,7 @@ static NSTimeInterval CrashCheckWaitLimit = 120;  // Time to wait for crash repo
         [self.logger logFormat:@"Bundle disconnected, with the test plan completed. Bundle exited successfully."];
         return FBFuture.empty;
       }
-      [self.logger logFormat:@"Bundle disconnected, but test plan has not completed. This could mean a crash has occured"];
+      [self.logger logFormat:@"Bundle disconnected, but test plan has not completed. This could mean a crash has occurred"];
       return [self
                failedFutureWithCrashLogOrNotFoundErrorDescription:@"Lost connection to test process, but could not find a crash log"];
     }];


### PR DESCRIPTION
Fix 3 instances across 3 files:

- `FBControlCore/Utility/FBProcessStream.h` line 79: Doc comment
- `XCTestBootstrap/MacStrategies/FBMacDevice.m` line 200: Log format string
- `XCTestBootstrap/TestManager/FBTestBundleConnection.m` line 323: Log format string

Comment/log-string-only change.