### PR TITLE
Fix stray 'f' prefix in dap log message

### DIFF
--- a/idb/grpc/client.py
+++ b/idb/grpc/client.py
@@ -1493,7 +1493,7 @@ class Client(ClientBase):
         ls_response = await self.ls(container=FileContainerType.ROOT, paths=["dap"])
         installed_daps = [entry.path for entry in ls_response[0].entries]
         if pkg_id in installed_daps:
-            self.logger.info(f"Dap pkg already exist. Id: f{pkg_id}")
+            self.logger.info(f"Dap pkg already exist. Id: {pkg_id}")
         else:
             self.logger.info(f"Pushing {path.absolute()} to simulator dap subfolder.")
             await self.push(


### PR DESCRIPTION
## Motivation

  While browsing `idb/grpc/client.py`, I noticed a curious log line in the `dap` flow:

  ```python
  self.logger.info(f"Dap pkg already exist. Id: f{pkg_id}")
  ```

  At first glance it looks fine — but look closer: the string is **already** an f-string (`f"..."`), yet there's another `f` sitting right before `{pkg_id}`. Inside an f-string, that stray `f` isn't a prefix
   — it's just a literal character. So every time this branch fires, the log prints:

  ```
  Dap pkg already exist. Id: fmy_package_id
  ```

  instead of the intended:

  ```
  Dap pkg already exist. Id: my_package_id
  ```

  A quick `git log -L` shows this has been quietly lying in the logs since the original `idb dap` command was added back in **Nov 2021** (commit `c25d48c8`). It never caused a functional break because it's
  just a log message — but anyone tailing logs and searching for a real `pkg_id` would miss it due to the phantom `f` prefix.

  This PR removes the stray `f` so the log message actually reflects the package id.

## Test Plan

  Verified the f-string behavior directly in Python:

  ```bash
  $ python3 -c "pkg_id='my_package'; print(f'Id: f{pkg_id}'); print(f'Id: {pkg_id}')"
  Id: fmy_package   # before
  Id: my_package    # after
  ```

  - `idb/grpc/client.py:1496` is a log-only line — no functional behavior changes.
  - No callers depend on this string.
  - Sibling log at line 1498 (`f"Pushing {path.absolute()} ..."`) already uses the correct pattern, so this change brings consistency to the block.

## Related PRs

  N/A — log message fix only, no API or docs impact.