### PR TITLE
Align install chunk size with tar.py/gzip.py (4MB)

### DIFF
--- a/idb/grpc/install.py
+++ b/idb/grpc/install.py
@@ -21,7 +21,7 @@ from idb.grpc.idb_pb2 import InstallRequest, Payload
 from idb.grpc.xctest import xctest_paths_to_tar
 
 
-CHUNK_SIZE = 16384
+CHUNK_SIZE = 1024 * 1024 * 4  # 4Mb, matching tar.py/gzip.py and well under the companion's 16Mb max receive size
 Destination = InstallRequest.Destination
 Bundle = Union[str, IO[bytes]]
 


### PR DESCRIPTION
## Motivation

  I was using `idb install` to deploy a moderately large `.ipa` onto a local simulator and the upload phase felt slower than I'd expect for what's essentially a localhost transfer. Out of curiosity I
  opened `idb/grpc/install.py` and noticed something that looked out of place:

  ```python
  CHUNK_SIZE = 16384  # 16 KB
  ```

  Meanwhile, sibling modules in the same repo stream much larger chunks:

  - `idb/common/tar.py:31` → `READ_CHUNK_SIZE = 1024 * 1024 * 4  # 4Mb, the default max read for gRPC`
  - `idb/common/gzip.py:18` → `READ_CHUNK_SIZE = 1024 * 1024 * 4  # 4Mb, the default max read for gRPC`

  And the companion's Swift server explicitly allows 16 MB per message:

  - `idb_companion/SwiftServer/GRPCSwiftServer.swift:62` → `serverConfiguration.maximumReceiveMessageLength = 16777216`

  Digging into the history, I found that `CHUNK_SIZE = 16384` was set back in 2019 (commit `a2be0a0a`) with the message:

  > "says it's between 16 and 64. we were currently using 1 so it's worth trying 16"

  That was a reasonable bump from 1 KB at the time, but since then both `tar.py` and `gzip.py` moved to 4 MB, and the companion is now configured to accept 16 MB. `install.py` is the only upload path that
  didn't move with them.

  ### Impact

  For a 500 MB `.ipa`, this changes the upload from ~32,000 gRPC messages to ~125 — a 256× reduction in per-message overhead (protobuf encoding, stream framing, async context switches). On loopback the
  effect is modest but visible; in remote-companion scenarios (CI, device farms) where network RTT amplifies per-message cost, the benefit scales much further.

  Importantly, `.app` / `.xctest` / `.dsym` / `.framework` / `.dylib` installs already route through `tar.generate_tar()` or `gzip.generate_gzip()`, so they've been sending 4 MB chunks to the **same**
  `install` gRPC endpoint successfully for years — this change just brings `.ipa` and `IO[bytes]` paths in line with them.

  ## Test Plan

  This change is a single constant adjustment with no behavioral changes to control flow, so verification is primarily static:

  - [x] **No new code paths** — `CHUNK_SIZE` is only read in two places (`_generate_ipa_chunks` and `generate_io_chunks`), both simple read-and-yield loops. Chunk size has no semantic meaning for gRPC
  streaming clients.
  - [x] **Chosen value is already proven in production** — `tar.py` and `gzip.py` have been streaming 4 MB chunks to the same `install` gRPC endpoint for `.app`/`.xctest`/`.dsym`/`.framework`/`.dylib`
  installs. If 4 MB caused issues, those paths would already be broken.
  - [x] **Safely under server limit** — companion's `maximumReceiveMessageLength` is 16 MB (`GRPCSwiftServer.swift:62`). A 4 MB payload plus protobuf overhead leaves ~12 MB of headroom.
  - [x] **Local smoke test** — installed a representative `.ipa` against a local simulator with the new chunk size; install completes successfully and is subjectively faster on the upload phase.

  ### What I did not test (and why)

  - **Remote companion / device farm setups**: I don't have access to that environment, but the change is purely numeric within an already-safe range proven by the sibling `.app` path. Reviewers with such
  setups should see a larger improvement than I did locally.
  - **Very large IPAs (>1 GB)**: Same reasoning — no behavioral branch depends on chunk size.

  If maintainers would like a specific size-stratified benchmark before merging, happy to add one.

  ## Related PRs

  N/A — this is a self-contained performance tweak. No API, docs, or public-interface changes.