### PR TITLE
refactor: Modernize Task.select to use structured TaskGroup

### DIFF
--- a/IDBCompanionUtilities/TaskSelect.swift
+++ b/IDBCompanionUtilities/TaskSelect.swift
@@ -7,71 +7,62 @@
 
 import Foundation
 
-struct TaskSelectState<Success: Sendable, Failure: Error>: Sendable {
-  var complete = false
-  var tasks: [Task<Success, Failure>]? = []
+extension Task where Success: Sendable {
 
-  mutating func add(_ task: Task<Success, Failure>) -> Task<Success, Failure>? {
-    if var tasks {
-      tasks.append(task)
-      self.tasks = tasks
-      return nil
-    } else {
-      return task
-    }
-  }
-}
-
-extension Task {
-  /// Determine the first task to complete of a sequence of tasks.
+  /// Returns the first task to complete out of a sequence of tasks.
   ///
-  /// - Parameters:
-  ///   - tasks: The running tasks to obtain a result from
-  /// - Returns: The first task to complete from the running tasks
+  /// Once a winner is determined, the remaining tasks are left to finish on
+  /// their own (matching prior behavior). If the surrounding task is
+  /// cancelled before a winner is selected, cancellation is propagated to
+  /// every input task.
+  ///
+  /// - Parameter tasks: The running tasks to await.
+  /// - Returns: The first task to complete, whether by success or failure.
+  /// - Precondition: `tasks` must not be empty.
   public static func select<Tasks: Sequence & Sendable>(
     _ tasks: Tasks
   ) async -> Task<Success, Failure>
-  where Tasks.Element == Task<Success, Failure>, Success: Sendable {
+  where Tasks.Element == Task<Success, Failure> {
 
-    let state = Atomic<TaskSelectState<Success, Failure>>(wrappedValue: .init())
+    // Snapshot once so the cancellation handler observes the exact same set
+    // of tasks that the task group is racing, without sharing mutable state.
+    let snapshot = Array(tasks)
+    precondition(!snapshot.isEmpty, "Task.select requires at least one task")
+
     return await withTaskCancellationHandler {
-      await withUnsafeContinuation { continuation in
-        for task in tasks {
-          Task<Void, Never> {
+      await withTaskGroup(of: Task<Success, Failure>.self) { group in
+        for task in snapshot {
+          group.addTask {
             _ = await task.result
-            let winner = state.sync { state -> Bool in
-              defer { state.complete = true }
-              return !state.complete
-            }
-            if winner {
-              continuation.resume(returning: task)
-            }
+            return task
           }
-          state.sync { state in
-            state.add(task)
-          }?.cancel()
         }
+
+        // The first child observer to finish carries our winner. Leaving the
+        // group implicitly cancels the remaining observer tasks via
+        // structured concurrency; the input tasks themselves are deliberately
+        // left running so callers can decide their fate.
+        return await group.next()!
       }
     } onCancel: {
-
-      let tasks = state.sync { state -> [Task<Success, Failure>] in
-        defer { state.tasks = nil }
-        return state.tasks ?? []
-      }
-      for task in tasks {
+      for task in snapshot {
         task.cancel()
       }
     }
   }
 
-  /// Determine the first task to complete of a list of tasks.
+  /// Returns the first task to complete out of a list of tasks.
   ///
-  /// - Parameters:
-  ///   - tasks: The running tasks to obtain a result from
-  /// - Returns: The first task to complete from the running tasks
+  /// Once a winner is determined, the remaining tasks are left to finish on
+  /// their own (matching prior behavior). If the surrounding task is
+  /// cancelled before a winner is selected, cancellation is propagated to
+  /// every input task.
+  ///
+  /// - Parameter tasks: The running tasks to await.
+  /// - Returns: The first task to complete, whether by success or failure.
   public static func select(
     _ tasks: Task<Success, Failure>...
-  ) async -> Task<Success, Failure> where Success: Sendable {
+  ) async -> Task<Success, Failure> {
     await select(tasks)
   }
 }

--- a/IDBCompanionUtilitiesTests/IDBCompanionUtilitiesTransientTests.swift
+++ b/IDBCompanionUtilitiesTests/IDBCompanionUtilitiesTransientTests.swift
@@ -108,6 +108,48 @@ final class IDBCompanionUtilitiesTransientTests: XCTestCase {
     XCTAssertTrue(task2.isCancelled)
   }
 
+  func testSelectReturnsFailingTaskWhenItFinishesFirst() async {
+    struct FastFailure: Error {}
+    let failingFast = Task<Int, Error> { throw FastFailure() }
+    let slow = Task<Int, Error> {
+      try await Task.sleep(nanoseconds: 5_000_000_000)
+      return 42
+    }
+
+    let winner = await Task.select(failingFast, slow)
+    do {
+      _ = try await winner.value
+      XCTFail("Expected FastFailure")
+    } catch {
+      XCTAssertTrue(error is FastFailure)
+    }
+    slow.cancel()
+  }
+
+  func testSelectWithSingleTaskReturnsThatTask() async {
+    let only = Task<Int, Never> { 7 }
+    let winner = await Task.select(only)
+    let value = await winner.value
+    XCTAssertEqual(value, 7)
+  }
+
+  func testSelectLeavesLosersRunning() async {
+    // Ensures that losing tasks are NOT cancelled when a winner is selected;
+    // callers retain ownership of remaining tasks.
+    let fast = Task<Int, Never> { 1 }
+    let slow = Task<Int, Never> {
+      try? await Task.sleep(nanoseconds: 100_000_000) // 100ms
+      return 2
+    }
+
+    let winner = await Task.select(fast, slow)
+    XCTAssertEqual(await winner.value, 1)
+
+    // The slow task should still be running (not cancelled).
+    XCTAssertFalse(slow.isCancelled)
+    XCTAssertEqual(await slow.value, 2)
+  }
+
   // MARK: - Task.timeout Tests
 
   func testTimeoutSucceedsWhenJobCompletesInTime() async throws {


### PR DESCRIPTION
##  Motivation

  While exploring the Swift side of idb, I noticed that Task.select in IDBCompanionUtilities is implemented using withUnsafeContinuation combined with an Atomic-backed state machine — a pattern that
  predates Swift's structured concurrency primitives. withTaskGroup is the standard-library primitive for this exact "first-to-complete" race, so this seemed like a natural modernization.

##  What changes

  - Task.select is reimplemented on top of withTaskGroup.
  - The internal TaskSelectState helper is removed.
  - The public API (both the Sequence overload and the variadic overload) is unchanged.
  - An empty-input precondition replaces the prior silent hang.
  - Docstrings are expanded to clarify the cancellation semantics that the previous implementation also exhibited.

##  Behavior preservation

  The previous implementation had two specific behaviors that callers depend on, both of which are preserved:

  1. Losing tasks are not auto-cancelled. Callers retain ownership of the remaining input tasks and choose when to cancel them (e.g., VideoStreamMethodHandler cancels the stream explicitly after
  Task.select returns).
  2. Outer cancellation cancels all input tasks via the withTaskCancellationHandler onCancel: block.

  Existing call sites in VideoStreamMethodHandler, LogMethodHandler, and TaskTimeout require no changes.

##  Test Plan

  The three existing Task.select tests pass unchanged, validating behavioral equivalence with the previous implementation:

  - testSelectReturnsFirstCompletedTask
  - testSelectWithSequence
  - testSelectCancellationCancelsTasks

  Three new tests are added to lock in previously-untested behavior:

  - testSelectReturnsFailingTaskWhenItFinishesFirst — verifies a task that throws first is correctly returned as the winner.
  - testSelectWithSingleTaskReturnsThatTask — boundary coverage.
  - testSelectLeavesLosersRunning — explicitly asserts that losing tasks continue running after a winner is selected, codifying the previously-undocumented contract.

  Indirect coverage via TaskTimeout (which uses Task.select internally) — the existing testTimeoutSucceedsWhenJobCompletesInTime, testTimeoutThrowsWhenJobExceedsTimeout, and testTimeoutPropagatesJobError
  exercise the new implementation end-to-end.

##  Related PRs

  N/A — this is a standalone refactor with no API surface change.