### PR TITLE
Fix #896: use asyncio.run() so idb launches on Python 3.10+

### DIFF
--- a/idb/cli/main.py
+++ b/idb/cli/main.py
@@ -370,11 +370,17 @@ async def drain_coroutines(pending: set[asyncio.Task]) -> None:
 
 
 def main(cmd_input: list[str] | None = None) -> SysExitArg:
-    loop = asyncio.get_event_loop()
-    try:
-        return loop.run_until_complete(gen_main(cmd_input))
-    finally:
-        loop.close()
+    # asyncio.run() is the canonical CLI entrypoint since Python 3.7 — it
+    # creates a fresh event loop, runs the coroutine, and closes the loop
+    # (including cancelling any pending tasks) in one call.
+    #
+    # The previous form `loop = asyncio.get_event_loop()` raised
+    # `RuntimeError: There is no current event loop in thread 'MainThread'`
+    # on Python ≥ 3.10 when no loop had been explicitly set — a behaviour
+    # change announced in 3.10 and enforced ever harder through 3.12+. By
+    # 3.14 it's the default and prevents `idb` from launching at all on a
+    # standard Python install (see #896, still reported as of 2026-04).
+    return asyncio.run(gen_main(cmd_input))
 
 
 def main_2() -> None:


### PR DESCRIPTION
## Summary

`idb/cli/main.py::main()` calls `asyncio.get_event_loop()` at top-level, which on Python ≥ 3.10 raises:

```
RuntimeError: There is no current event loop in thread 'MainThread'
```

…when no event loop has been explicitly set on the main thread. Python 3.10 deprecated implicit-loop creation; 3.12+ enforces it as a hard error. By 3.14 (now the default for `brew install python` on macOS) **`idb` will not launch at all** — every invocation crashes during startup. This blocks `idb`, `idb udid`, `idb list-targets`, etc. for any user on a modern Python.

## The fix

Replace the manual `asyncio.get_event_loop()` + `loop.run_until_complete()` + `loop.close()` pattern with `asyncio.run(...)`. This is the canonical CLI entrypoint introduced in Python 3.7. It:

- Creates a fresh event loop (no implicit-loop semantics)
- Runs the coroutine to completion
- Cancels pending tasks and closes the loop in a single call
- Is the documented Python idiom for synchronous-to-async transitions in CLI tools

Behaviour is identical to the previous pattern on Python 3.7-3.9 (where `get_event_loop()` auto-created a loop when none existed), and now also works on 3.10-3.14+.

## Context

- Reported as #896 (2025-11-26, marked completed 2026-02-04 with a user-workaround comment but never patched upstream).
- @zetlen confirmed it was still reproducing as of 2026-04-10.
- I re-confirmed it on `fb-idb 1.1.7` / Python `3.14.2` (current `brew` defaults) today.
- Local workaround in our deployment: a `patch-idb.sh` script that rewrites the function in-place after every `brew upgrade`. This PR upstreams the fix so that's no longer necessary for anyone.

## Test plan

- [ ] Install on a Python 3.14 environment (`pipx install --python python3.14 fb-idb` from this branch's wheel)
- [ ] Run `idb list-targets` — should print target list (not RuntimeError)
- [ ] Run `idb udid` — should print UDID (not RuntimeError)
- [ ] Run any subcommand that exits non-zero — verify the process actually exits non-zero (asyncio.run propagates the return value through `sys.exit(main())` in `main_2()`)
- [ ] Re-run unchanged on Python 3.9 (the documented minimum) — should keep working

## Notes

This is a one-line semantic change wrapped in a comment block explaining the why. The previous form's `try/finally` was redundant given that `asyncio.run()` already handles loop cleanup; removing it is intentional, not a bug.