### PR TITLE
perf: Compile XCTest assertion-failure regex once instead of per log line

### DIFF
--- a/idb_companion/Utility/IDBXCTestReporter/IDBXCTestReporter.swift
+++ b/idb_companion/Utility/IDBXCTestReporter/IDBXCTestReporter.swift
@@ -488,21 +488,21 @@ extension IDBXCTestReporter {
     return createResponse(logOutput: logOutput)
   }
 
+  private static let assertionFailureRegex: NSRegularExpression = {
+    // swiftlint:disable:next force_try
+    try! NSRegularExpression(pattern: "Assertion failed: (.*), function (.*), file (.*), line (\\d+).", options: .caseInsensitive)
+  }()
+
   private func extractFailureInfo(from logOutput: String) {
-    do {
-      let regexp = try NSRegularExpression(pattern: "Assertion failed: (.*), function (.*), file (.*), line (\\d+).", options: .caseInsensitive)
-      let log = logOutput as NSString
-      if let result = regexp.firstMatch(in: logOutput, options: [], range: .init(location: 0, length: log.length)) {
-        _currentInfo.sync {
-          $0.failureInfo = failureInfoWith(
-            message: log.substring(with: result.range(at: 1)),
-            file: log.substring(with: result.range(at: 3)),
-            line: UInt(log.substring(with: result.range(at: 4))) ?? 0)
-        }
-      }
-    } catch {
-      assertionFailure(error.localizedDescription)
-      logger.error().log("Incorrect regexp \(error.localizedDescription)")
+    let log = logOutput as NSString
+    guard let result = Self.assertionFailureRegex.firstMatch(in: logOutput, options: [], range: .init(location: 0, length: log.length)) else {
+      return
+    }
+    _currentInfo.sync {
+      $0.failureInfo = failureInfoWith(
+        message: log.substring(with: result.range(at: 1)),
+        file: log.substring(with: result.range(at: 3)),
+        line: UInt(log.substring(with: result.range(at: 4))) ?? 0)
     }
   }
 


### PR DESCRIPTION
## Motivation

`IDBXCTestReporter.extractFailureInfo` builds its `NSRegularExpression` from a constant pattern on every call, and that method runs once per line of test output: `FBLogicTestRunStrategy` reports stdout/stderr line-by-line via `asynchronousLineConsumer` -> `testHadOutput` -> `extractFailureInfo`. A test that prints a lot of output recompiles the same constant regex tens of thousands of times, even though the pattern never changes.

This hoists the pattern into a `private static let` compiled once and reused, matching how constant regexes are already handled elsewhere in the codebase (`FBCodesignProvider`, `FBSimulatorApplicationCommands`, `FBSimulatorLaunchCtlCommands`). The `do/catch` is no longer needed since the only throwing call now runs once in the static initializer.

## Test Plan

- Behavior is unchanged: same pattern, same options, same `firstMatch` call and ranges. The removed `do/catch` only guarded compilation of a constant pattern, which cannot fail (the previous code treated such failure as fatal via `assertionFailure`).
- `NSRegularExpression` is immutable and thread-safe, so the shared static instance is safe across concurrent reporters.
- Isolated micro-benchmark of the per-line work, 10,000 lines × 100 iterations (release):

| Metric | Before (recompile per line) | After (compile once) |
|--------|------------------------------|----------------------|
| Typical log output | ~10.1 s | ~1.1 s (~9×) |
| Plain log lines (no matches) | ~10.5 s | ~0.9 s (~11×) |

(A `contains` pre-filter was tried but benchmarked ~2× *slower* than matching the precompiled regex, so it was not included.)

## Related PRs

- #905 — same shape of per-line optimization on the XCTest path (skipping redundant work for every log line); that one was on the Python log parser, this is the Swift companion's reporter.