### PR TITLE
Hoist per-call DateFormatter and regex out of result-bundle parsing

### DIFF
--- a/XCTestBootstrap/Utility/FBXCTestResultBundleParser.swift
+++ b/XCTestBootstrap/Utility/FBXCTestResultBundleParser.swift
@@ -76,10 +76,14 @@ private func accessAndUnwrapValue(_ dict: NSDictionary, _ key: String, _ logger:
   return unwrapped
 }
 
+private let FBXCTestResultBundleParser_dateFormatter: DateFormatter = {
+  let formatter = DateFormatter()
+  formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
+  return formatter
+}()
+
 private func dateFromString(_ date: String) -> Date? {
-  let dateFormatter = DateFormatter()
-  dateFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
-  return dateFormatter.date(from: date)
+  return FBXCTestResultBundleParser_dateFormatter.date(from: date)
 }
 
 @objc public final class FBXCTestResultBundleParser: NSObject {
@@ -550,11 +554,15 @@ private func dateFromString(_ date: String) -> Date? {
     return subdirectoryFullPath
   }
 
+  private static let screenshotFilenameRegex: NSRegularExpression = {
+    // swiftlint:disable:next force_try
+    try! NSRegularExpression(pattern: "^Screenshot_.*", options: [])
+  }()
+
   private static func extractScreenshotsFromAttachments(_ attachments: [NSDictionary], to destination: String, queue: DispatchQueue, resultBundlePath: String, logger: FBControlCoreLogger) {
-    guard let regex = try? NSRegularExpression(pattern: "^Screenshot_.*", options: []) else { return }
     for attachment in attachments {
       guard let filename = accessAndUnwrapValue(attachment, "filename", logger) as? String else { continue }
-      let matchResult = regex.firstMatch(in: filename, options: [], range: NSRange(location: 0, length: (filename as NSString).length))
+      let matchResult = FBXCTestResultBundleParser.screenshotFilenameRegex.firstMatch(in: filename, options: [], range: NSRange(location: 0, length: (filename as NSString).length))
       if attachment["payloadRef"] != nil && matchResult != nil {
         let timestamp = accessAndUnwrapValue(attachment, "timestamp", logger) as? String ?? ""
         let jpgFilename = (filename as NSString).deletingPathExtension.appending(".jpg")


### PR DESCRIPTION
## Motivation

This continues a series improving idb's XCTest output processing (#927, #905). While reading how idb turns an xcresult bundle into per-test log output, I found the same anti-pattern #927 fixed in the test reporter, on another path: `dateFromString` in `FBXCTestResultBundleParser` builds a fresh `DateFormatter` on every call, and it is called once per activity node across the recursive activity-tree traversal (`buildTestLog` and the self-recursive `addTestLogsFromActivitySummary`). So a large UI-test bundle constructs and configures one formatter per node, and `DateFormatter` is one of the more expensive Foundation objects to construct. The constant `"^Screenshot_.*"` `NSRegularExpression` in `extractScreenshotsFromAttachments` isrecompiled on every call in the same way. As in #927, the codebase already hoists such constants elsewhere (`FBCrashLog_dateFormatter` in `FBCrashLog.swift`, `cdHashRegex` in `FBCodesignProvider.swift`); this brings the result-bundle parser in line with that idiom.

## Test Plan

Behavior is unchanged: the format string and regex pattern are identical, and both shared instances are configured once and only read afterwards. `DateFormatter.date(from:)` and `NSRegularExpression.firstMatch` are safe for concurrent reads when the instance is not mutated, which matches how the parser is driven (its work is dispatched onto a concurrent queue, like the existing shared `FBCrashLog_dateFormatter`). A standalone micro-benchmark shows the per-call construction is ~1.9x the cost of the reused formatter (~134µs vs ~72µs); unlike the per-line paths in #927/#905 this parser runs once per test run, so it removes a noticeable amount of work only on large UI-test bundles with many activity nodes, and is negligible for typical runs.

## Related PRs

Part of a series improving idb's XCTest output processing:
- #927 — same technique (hoisting a constant regex out of a per-call path), on the test reporter. This PR applies it to the result-bundle parser and also to a per-call `DateFormatter`.
- #905 — same theme (faster XCTest log handling) via fast-rejection in the Python log parser.