### PR TITLE
fix: Send each chunk from its real offset in FBAMDServiceConnection so payloads larger than 4KB aren't corrupted

### DIFF
--- a/FBDeviceControl/Management/FBAMDServiceConnection.m
+++ b/FBDeviceControl/Management/FBAMDServiceConnection.m
@@ -242,7 +242,7 @@ static size_t SendBufferSize = 1024 * 4;
   // Start a loop that ends when there's no more bytes to send
   while (bytesRemaining > 0) {
     // Send the bytes now
-    NSRange sendRange = NSMakeRange(data.length - data.length, MIN(SendBufferSize, bytesRemaining));
+    NSRange sendRange = NSMakeRange(data.length - bytesRemaining, MIN(SendBufferSize, bytesRemaining));
     NSData *chunkData = [data subdataWithRange:sendRange];
     ssize_t result = [self send:chunkData.bytes size:chunkData.length];
     // A negative return indicates error.


### PR DESCRIPTION
## Motivation

While reading the send/receive chunking in `FBAMDServiceConnection`, I noticed that `-[FBAMDServiceConnection send:error:]` computes each chunk's offset as `NSMakeRange(data.length - data.length, ...)`. `data.length - data.length` is always 0, so the offset never advances. As long as the payload fits in a single `SendBufferSize` (4KB) chunk the loop runs once and happens to be correct, but once the payload is larger than 4KB every subsequent iteration re-sends the first chunk from offset 0 instead of moving forward. The peer ends up with the leading bytes repeated and never receives the tail of the payload — silent data corruption.

This path is used by raw `send:` callers, most notably the debugserver relay: `FBDeviceDebugServer` forwards lldb traffic with `connection.send(availableData)`, and a single socket read there can exceed 4KB. plist messaging is unaffected because it goes through `ServiceConnectionSendMessage` rather than this chunking loop.

## Test Plan

The offset should be the number of bytes already sent, `data.length - bytesRemaining`. A standalone reproduction of the chunking loop confirms it: with the original offset a 10KB payload is transmitted as chunk0, chunk0, chunk0 (the first 4KB repeated) and does not match the source; with `data.length - bytesRemaining` it is transmitted as chunk0, chunk1, chunk2 and matches the source byte-for-byte. Payloads of 4KB or less are unaffected, since the loop runs a single iteration. `FBDeviceControl` builds. The path needs a physical device to exercise end to end, so it isn't covered by a unit test here; the fix is verified by the standalone reproduction and by inspection.

## Related PRs

None.