### PR TITLE
perf: Parallelize xctest result-bundle, coverage, and log finalization

### DIFF
--- a/idb_companion/Utility/IDBXCTestReporter/IDBXCTestReporter.swift
+++ b/idb_companion/Utility/IDBXCTestReporter/IDBXCTestReporter.swift
@@ -295,36 +295,65 @@ extension IDBXCTestReporter {
     }
   }
 
-  // TODO: Parallelism of execution was lost after rewriting this method to swift. Make this work in parallel again
+  /// One of the independent, heavyweight artifacts assembled at the end of a test run.
+  private enum FinalArtifact {
+    case resultBundle(Data)
+    case coverage(Data)
+    case logDirectory(Data)
+  }
+
   private func insertFinalDataThenWriteResponse(response: Idb_XctestRunResponse) async throws {
     var response = response
 
-    if !configuration.resultBundlePath.isEmpty && configuration.reportResultBundle {
-      do {
-        let resultBundle = try await gzipFolder(at: configuration.resultBundlePath)
-        response.resultBundle = .with {
-          $0.data = resultBundle
+    // Run the three independent finalization steps concurrently, restoring the parallelism of the
+    // original ObjC reporter (`+[FBFuture futureWithFutures:]`). A task group keeps this consistent
+    // with the companion's other concurrent work (LaunchMethodHandler, ConcurrentForEach).
+    let artifacts: [FinalArtifact] = try await withThrowingTaskGroup(of: FinalArtifact?.self) { group in
+      if !configuration.resultBundlePath.isEmpty && configuration.reportResultBundle {
+        group.addTask {
+          do {
+            return .resultBundle(try await self.gzipFolder(at: self.configuration.resultBundlePath))
+          } catch {
+            self.logger.info().log("Failed to create result bundle \(error.localizedDescription)")
+            return nil
+          }
         }
-      } catch {
-        logger.info().log("Failed to create result bundle \(error.localizedDescription)")
       }
+
+      if let coverageConfig = configuration.coverageConfiguration, !coverageConfig.coverageDirectory.isEmpty {
+        group.addTask {
+          do {
+            return .coverage(try await self.getCoverageResponseData(config: coverageConfig))
+          } catch {
+            self.logger.info().log("Failed to get coverage data: \(error.localizedDescription)")
+            return nil
+          }
+        }
+      }
+
+      if let logDirectoryPath = configuration.logDirectoryPath {
+        group.addTask {
+          .logDirectory(try await self.gzipFolder(at: logDirectoryPath))
+        }
+      }
+
+      var collected: [FinalArtifact] = []
+      for try await artifact in group {
+        if let artifact {
+          collected.append(artifact)
+        }
+      }
+      return collected
     }
 
-    if let coverageConfig = configuration.coverageConfiguration, !coverageConfig.coverageDirectory.isEmpty {
-      do {
-        let coverageData = try await getCoverageResponseData(config: coverageConfig)
-        response.codeCoverageData = .with {
-          $0.data = coverageData
-        }
-      } catch {
-        logger.info().log("Failed to get coverage data: \(error.localizedDescription)")
-      }
-    }
-
-    if let logDirectoryPath = configuration.logDirectoryPath {
-      let data = try await gzipFolder(at: logDirectoryPath)
-      response.logDirectory = .with {
-        $0.data = data
+    for artifact in artifacts {
+      switch artifact {
+      case let .resultBundle(data):
+        response.resultBundle = .with { $0.data = data }
+      case let .coverage(data):
+        response.codeCoverageData = .with { $0.data = data }
+      case let .logDirectory(data):
+        response.logDirectory = .with { $0.data = data }
       }
     }
 


### PR DESCRIPTION
## Motivation

At the end of a test run, `IDBXCTestReporter.insertFinalDataThenWriteResponse` assembles up to three heavyweight artifacts into the final `XctestRunResponse`:

- the gzipped **result bundle**,
- the exported **code coverage** data (an `llvm-profdata` merge + `llvm-cov` export), and
- the gzipped **log directory**.

These are independent, multi-second operations, but they run sequentially — one `await` after another. The method has carried a TODO about this since the reporter was first ported from Objective-C to Swift (commit `Implement swift IDBXCTestReporter`, Feb 2022), and the line has sat untouched ever since:

```swift
// TODO: Parallelism of execution was lost after rewriting this method to swift. Make this work in parallel again
```

The original Objective-C reporter ran the three steps concurrently, collecting their `FBFuture`s and awaiting them together via `+[FBFuture futureWithFutures:]`. The Swift port serialized them. This PR restores the parallelism.

I noticed the TODO while working in this same file on #927.

## Modifications

Run the three finalization steps in a `withThrowingTaskGroup` and fold each result into the response as it completes, instead of `await`-ing them one by one. Behavior is otherwise identical to the current sequential code:

- Same gating conditions decide which artifacts are produced.
- Per-artifact error handling is preserved exactly: a result-bundle or coverage
  failure is logged and skipped; a log-directory failure still propagates.
- The response fields populated and the final `writeResponseFinal` call are
  identical; only the scheduling of the three steps changed.

A task group is used to stay consistent with the companion's existing concurrent code (`LaunchMethodHandler`, `ConcurrentForEach`).

## Measurements

End-of-run finalization changes from the **sum** of the three artifact times to the **slowest** one. Benchmarked the dominant work (tar+gzip) on representative directories (result-bundle ~64 MB, logs ~24 MB, coverage ~21 MB), wall-clock, 3 runs each:

| | sequential | parallel |
|---|---|---|
| mean | ~5.3 s | ~3.1 s |

Individually: 2.56 s + 0.89 s + 1.00 s (sum 4.45 s) vs. max 2.56 s — confirming the sum→max behavior (~1.7x, ~2.2 s saved on this workload). The absolute saving grows with artifact size, and the real coverage export (`llvm-cov`) adds further parallelizable time on top of the gzip measured here.

Honest scope: this benefits runs that request **more than one** artifact (a single-artifact run is unaffected); the floor is the largest single artifact; and the numbers above are a local proxy for the gzip/export work, not a full end-to-end `idb xctest run`.

## Test Plan

- `./build.sh build idb_companion` builds cleanly (no new warnings).
- Behavioral equivalence vs. the previous sequential code was verified across all paths — both artifacts-present combinations and the three error paths (result-bundle / coverage swallowed-and-logged; log-directory propagated): the set of populated response fields, whether the method throws, and whether the final response is written are identical in every case.

## Related PRs

- #927 — same file (compiles the assertion-failure regex once).