### PR TITLE
Clamp swipe step count to at least one to avoid NaN coordinates

### DIFF
--- a/FBSimulatorControl/HID/FBSimulatorHIDEvent.swift
+++ b/FBSimulatorControl/HID/FBSimulatorHIDEvent.swift
@@ -164,7 +164,7 @@ public extension FBSimulatorHIDEvent {
     if effectiveDelta <= 0.0 {
       effectiveDelta = DEFAULT_SWIPE_DELTA
     }
-    let steps = Int(distance / effectiveDelta)
+    let steps = max(1, Int(distance / effectiveDelta))
 
     let dx = (xEnd - xStart) / Double(steps)
     let dy = (yEnd - yStart) / Double(steps)

--- a/FBSimulatorControlTests/Tests/Unit/FBSimulatorControlTransientTests.swift
+++ b/FBSimulatorControlTests/Tests/Unit/FBSimulatorControlTransientTests.swift
@@ -276,6 +276,21 @@ final class FBSimulatorControlTransientTests: XCTestCase {
     XCTAssertEqual(swipe.subEvents?.count, expectedEvents)
   }
 
+  func testSwipeShorterThanDeltaClampsToOneStep() {
+    // distance = 5 < delta 10 gives Int(0.5) = 0 steps, which divides by zero in
+    // dx/dy and yields NaN touch coordinates. Steps must be clamped to at least 1,
+    // mirroring `pinchAt` and `pan`.
+    let swipe = FBSimulatorHIDEvent.swipe(0, yStart: 0, xEnd: 5, yEnd: 0, delta: 10, duration: 1.0)
+    let expectedSteps = 1
+    let expectedEvents = (expectedSteps + 1) * 2 + 2 + 1
+    XCTAssertEqual(swipe.subEvents?.count, expectedEvents)
+    for event in swipe.subEvents ?? [] {
+      if case let .touch(_, x, y) = event {
+        XCTAssertTrue(x.isFinite && y.isFinite, "Swipe produced a non-finite coordinate (\(x), \(y))")
+      }
+    }
+  }
+
   func testSwipeEndsWithTouchUp() {
     let swipe = FBSimulatorHIDEvent.swipe(0, yStart: 0, xEnd: 50, yEnd: 0, delta: 10, duration: 0.5)
     guard let last = swipe.subEvents?.last else {


### PR DESCRIPTION
## Motivation

While reading the HID gesture builders in `FBSimulatorHIDEvent`, I noticed that `swipe` derives its interpolation step count from `steps = Int(distance / effectiveDelta)` without the clamp its sibling gestures have. When the swipe distance is shorter than the delta — for example a 5pt swipe with the default 10pt `DEFAULT_SWIPE_DELTA` — `Int(0.5)` truncates to `0`. The next line, `dx = (xEnd - xStart) / Double(steps)`, then divides by zero to `inf`, and `inf * 0` in the interpolation loop makes every emitted touch event carry NaN coordinates — a short swipe silently degrades into garbage input instead of a small, valid gesture.

`pinchAt` already guards this with `if steps < 2 { steps = 2 }` and the tvOS `pan` builder uses `max(1, steps)`; `swipe` is the only interpolating gesture missing the clamp. It is reachable from normal usage — `idb ui swipe 0 0 5 0` (a sub-delta swipe) hits it directly.

## Test Plan

Steps must be at least 1 for the `0...steps` interpolation loop, so clamping with `max(1, ...)` — mirroring `pan` — is the minimal fix. Added `testSwipeShorterThanDeltaClampsToOneStep` next to the existing swipe step-count tests: it runs a 5pt swipe with delta 10 and asserts both that the event count matches a single clamped step and that no emitted touch event carries a non-finite coordinate. It fails before the change (NaN coordinates, wrong count) and passes after.

A standalone reproduction of the arithmetic confirms it: before, the short swipe emits touch points `(-nan, -nan) (-nan, -nan) (5, 0)`; after, `(0, 0) (5, 0) (5, 0) (5, 0)` — all finite. A normal 100pt swipe is unchanged (13 events, no NaN), so this is a pure guard with no regression.

## Related PRs

None.