### PR TITLE
fix(video): support iOS device recording on macOS 26 Tahoe

### DIFF
--- a/Companion/Info.plist
+++ b/Companion/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>NSCameraUsageDescription</key>
 	<string>Recording video from your device</string>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>

--- a/Companion/project.yml
+++ b/Companion/project.yml
@@ -133,6 +133,7 @@ targets:
         SWIFT_VERSION: "5.0"
         SWIFT_OBJC_INTERFACE_HEADER_NAME: idb-Swift.h
         INFOPLIST_FILE: $(SRCROOT)/Info.plist
+        CREATE_INFOPLIST_SECTION_IN_BINARY: YES
         HEADER_SEARCH_PATHS: $(inherited) $(SRCROOT)/../PrivateHeaders
         FRAMEWORK_SEARCH_PATHS: $(inherited) $(SRCROOT)/../Build/Products/Release
         # Suppress warnings for existing code patterns that trigger errors with strict settings

--- a/FBDeviceControl/Video/FBDeviceVideo.swift
+++ b/FBDeviceControl/Video/FBDeviceVideo.swift
@@ -10,9 +10,21 @@ import CoreMediaIO
 @preconcurrency import FBControlCore
 import Foundation
 
+protocol FBDeviceVideoCaptureDeviceCandidate {
+  var uniqueID: String { get }
+  var localizedName: String { get }
+  var modelID: String { get }
+
+  func hasMediaType(_ mediaType: AVMediaType) -> Bool
+}
+
+extension AVCaptureDevice: FBDeviceVideoCaptureDeviceCandidate {}
+
 public final class FBDeviceVideo {
   private let encoder: FBVideoFileWriter
   private let workQueue: DispatchQueue
+
+  private static let captureDeviceDiscoveryPollNanoseconds: UInt64 = 250_000_000
 
   // MARK: Initialization Helpers
 
@@ -92,17 +104,125 @@ public final class FBDeviceVideo {
     }
   }
 
+  private class func normalizedIdentifier(_ identifier: String) -> String {
+    identifier
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .joined()
+      .lowercased()
+  }
+
+  static func captureDevice<Candidate: FBDeviceVideoCaptureDeviceCandidate>(
+    forUDID targetUDID: String,
+    named targetName: String,
+    connectedDeviceUDIDs: [String],
+    from candidates: [Candidate]
+  ) -> Candidate? {
+    let normalizedUDID = normalizedIdentifier(targetUDID)
+    var screenCandidates: [Candidate] = []
+    var identifierMatches: [Candidate] = []
+    var nameMatches: [Candidate] = []
+
+    for candidate in candidates {
+      guard candidate.modelID == "iOS Device", candidate.hasMediaType(.muxed) else {
+        continue
+      }
+      screenCandidates.append(candidate)
+
+      let normalizedCandidateID = normalizedIdentifier(candidate.uniqueID)
+      if !normalizedUDID.isEmpty, normalizedCandidateID.contains(normalizedUDID) {
+        identifierMatches.append(candidate)
+      }
+      if candidate.localizedName == targetName {
+        nameMatches.append(candidate)
+      }
+    }
+
+    if !identifierMatches.isEmpty {
+      return identifierMatches.count == 1 ? identifierMatches[0] : nil
+    }
+    if !nameMatches.isEmpty {
+      return nameMatches.count == 1 ? nameMatches[0] : nil
+    }
+    if screenCandidates.count == 1,
+       connectedDeviceUDIDs.count == 1,
+       connectedDeviceUDIDs[0] == targetUDID
+    {
+      return screenCandidates[0]
+    }
+    return nil
+  }
+
+  private class func captureDeviceInventory(_ candidates: [AVCaptureDevice]) -> String {
+    let descriptions = candidates.map { candidate in
+      var mediaTypes: [String] = []
+      if candidate.hasMediaType(.video) {
+        mediaTypes.append("video")
+      }
+      if candidate.hasMediaType(.audio) {
+        mediaTypes.append("audio")
+      }
+      if candidate.hasMediaType(.muxed) {
+        mediaTypes.append("muxed")
+      }
+      return "{name=\(candidate.localizedName), uniqueID=\(candidate.uniqueID), modelID=\(candidate.modelID), deviceType=\(candidate.deviceType.rawValue), mediaTypes=\(mediaTypes.joined(separator: ","))}"
+    }.sorted()
+    return descriptions.isEmpty ? "<none>" : descriptions.joined(separator: "; ")
+  }
+
+  private class func captureDeviceDiscoverySession() -> AVCaptureDevice.DiscoverySession {
+    if #available(macOS 14.0, *) {
+      return AVCaptureDevice.DiscoverySession(
+        deviceTypes: [.external, .continuityCamera],
+        mediaType: nil,
+        position: .unspecified
+      )
+    }
+    return AVCaptureDevice.DiscoverySession(
+      deviceTypes: [.externalUnknown],
+      mediaType: nil,
+      position: .unspecified
+    )
+  }
+
   private class func findCaptureDeviceAsync(for device: FBDevice) async throws -> AVCaptureDevice {
     let timeout = FBControlCoreGlobalConfiguration.fastTimeout
     let deadline = Date().addingTimeInterval(timeout)
+    let logger = device.logger ?? FBControlCoreGlobalConfiguration.defaultLogger
+    var discoverySession: AVCaptureDevice.DiscoverySession?
+    var lastInventory: String?
+
     while true {
       if let captureDevice = AVCaptureDevice(uniqueID: device.udid) {
         return captureDevice
       }
+
+      if discoverySession == nil {
+        discoverySession = captureDeviceDiscoverySession()
+      }
+      let candidates = discoverySession?.devices ?? []
+      let inventory = captureDeviceInventory(candidates)
+      if inventory != lastInventory {
+        logger.log("[FBDeviceVideo] Capture device candidates: \(inventory)")
+        lastInventory = inventory
+      }
+
+      let connectedDeviceUDIDs = device.set?.allDevices.map(\.udid) ?? []
+      if let captureDevice = captureDevice(
+        forUDID: device.udid,
+        named: device.name,
+        connectedDeviceUDIDs: connectedDeviceUDIDs,
+        from: candidates
+      ) {
+        logger.log(
+          "[FBDeviceVideo] Matched screen capture device name=\(captureDevice.localizedName) uniqueID=\(captureDevice.uniqueID) modelID=\(captureDevice.modelID)"
+        )
+        return captureDevice
+      }
+
       if Date() >= deadline {
         throw FBDeviceControlError.describe("Timed out waiting \(timeout)s for device \(device) to have an associated capture device appear").build()
       }
-      try await Task.sleep(nanoseconds: 100_000_000)
+      try await Task.sleep(nanoseconds: captureDeviceDiscoveryPollNanoseconds)
     }
   }
 

--- a/FBDeviceControl/Video/FBDeviceVideo.swift
+++ b/FBDeviceControl/Video/FBDeviceVideo.swift
@@ -16,6 +16,62 @@ public final class FBDeviceVideo {
 
   // MARK: Initialization Helpers
 
+  private class func videoCaptureAuthorizationStatusString(_ status: AVAuthorizationStatus) -> String {
+    switch status {
+    case .notDetermined:
+      return "notDetermined"
+    case .restricted:
+      return "restricted"
+    case .denied:
+      return "denied"
+    case .authorized:
+      return "authorized"
+    @unknown default:
+      return "unknown(\(status.rawValue))"
+    }
+  }
+
+  private class func videoCaptureAuthorizationError(_ status: AVAuthorizationStatus) -> Error {
+    if status == .denied {
+      return FBDeviceControlError.describe(
+        "Camera authorization is denied. Grant camera access to the application responsible for idb_companion in System Settings > Privacy & Security > Camera"
+      ).build()
+    }
+    if status == .restricted {
+      return FBDeviceControlError.describe("Camera authorization is restricted by system policy").build()
+    }
+    return FBDeviceControlError.describe(
+      "Camera authorization request did not grant access (status: \(videoCaptureAuthorizationStatusString(status)))"
+    ).build()
+  }
+
+  static func ensureVideoCaptureAuthorization(
+    logger: any FBControlCoreLogger,
+    authorizationStatus: () -> AVAuthorizationStatus,
+    requestAccess: () async -> Bool
+  ) async throws {
+    let status = authorizationStatus()
+    logger.log("[FBDeviceVideo] Camera authorization status: \(videoCaptureAuthorizationStatusString(status))")
+
+    switch status {
+    case .authorized:
+      return
+    case .denied, .restricted:
+      throw videoCaptureAuthorizationError(status)
+    case .notDetermined:
+      let granted = await requestAccess()
+      let finalStatus = authorizationStatus()
+      logger.log(
+        "[FBDeviceVideo] Camera authorization status after request: \(videoCaptureAuthorizationStatusString(finalStatus)) (granted=\(granted ? "YES" : "NO"))"
+      )
+      guard granted, finalStatus == .authorized else {
+        throw videoCaptureAuthorizationError(finalStatus)
+      }
+    @unknown default:
+      throw videoCaptureAuthorizationError(status)
+    }
+  }
+
   private class func allowAccessToScreenCaptureDevices() throws {
     var properties = CMIOObjectPropertyAddress(
       mSelector: CMIOObjectPropertySelector(kCMIOHardwarePropertyAllowScreenCaptureDevices),
@@ -53,8 +109,37 @@ public final class FBDeviceVideo {
   // MARK: Initializers
 
   public class func captureSessionAsync(for device: FBDevice) async throws -> AVCaptureSession {
+    try await captureSessionAsync(
+      logger: device.logger ?? FBControlCoreGlobalConfiguration.defaultLogger,
+      authorizationStatus: {
+        AVCaptureDevice.authorizationStatus(for: .video)
+      },
+      requestAccess: {
+        await AVCaptureDevice.requestAccess(for: .video)
+      },
+      allowAccessToScreenCaptureDevices: {
+        try allowAccessToScreenCaptureDevices()
+      },
+      findCaptureDevice: {
+        try await findCaptureDeviceAsync(for: device)
+      }
+    )
+  }
+
+  static func captureSessionAsync(
+    logger: any FBControlCoreLogger,
+    authorizationStatus: () -> AVAuthorizationStatus,
+    requestAccess: () async -> Bool,
+    allowAccessToScreenCaptureDevices: () throws -> Void,
+    findCaptureDevice: () async throws -> AVCaptureDevice
+  ) async throws -> AVCaptureSession {
+    try await ensureVideoCaptureAuthorization(
+      logger: logger,
+      authorizationStatus: authorizationStatus,
+      requestAccess: requestAccess
+    )
     try allowAccessToScreenCaptureDevices()
-    let captureDevice = try await findCaptureDeviceAsync(for: device)
+    let captureDevice = try await findCaptureDevice()
     let deviceInput = try AVCaptureDeviceInput(device: captureDevice)
     let session = AVCaptureSession()
     if !session.canAddInput(deviceInput) {

--- a/FBDeviceControlTests/Tests/Unit/FBDeviceVideoTests.swift
+++ b/FBDeviceControlTests/Tests/Unit/FBDeviceVideoTests.swift
@@ -11,6 +11,29 @@ import FBControlCore
 import XCTest
 
 final class FBDeviceVideoTests: XCTestCase {
+  private final class CaptureDeviceStub: FBDeviceVideoCaptureDeviceCandidate {
+    let uniqueID: String
+    let localizedName: String
+    let modelID: String
+    let mediaTypes: [AVMediaType]
+
+    init(
+      uniqueID: String,
+      localizedName: String,
+      modelID: String,
+      mediaTypes: [AVMediaType] = []
+    ) {
+      self.uniqueID = uniqueID
+      self.localizedName = localizedName
+      self.modelID = modelID
+      self.mediaTypes = mediaTypes
+    }
+
+    func hasMediaType(_ mediaType: AVMediaType) -> Bool {
+      mediaTypes.contains(mediaType)
+    }
+  }
+
   private final class AuthorizationStub {
     var status: AVAuthorizationStatus
     let statusAfterRequest: AVAuthorizationStatus?
@@ -190,5 +213,139 @@ final class FBDeviceVideoTests: XCTestCase {
 
     XCTAssertEqual(allowScreenCaptureCount, 0)
     XCTAssertEqual(findCaptureDeviceCount, 0)
+  }
+
+  func testCaptureDeviceFallsBackToSingleExactNameIOSScreenCaptureMatch() {
+    let continuityCamera = CaptureDeviceStub(
+      uniqueID: "18FF4BAB-BBC5-497B-90FF-466300000001",
+      localizedName: "Test iPhone Camera",
+      modelID: "iPhone17,2"
+    )
+    let screenCapture = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "Test iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: ["00008140-00025981013B001C"],
+      from: [continuityCamera, screenCapture]
+    )
+
+    XCTAssertTrue(match === screenCapture)
+  }
+
+  func testCaptureDevicePrefersNormalizedUDIDMatchOverNameMatch() {
+    let nameMatch = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "Test iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+    let udidMatch = CaptureDeviceStub(
+      uniqueID: "com.apple.cmio.0000814000025981013B001C.screen",
+      localizedName: "A Different iPhone Name",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: ["00008140-00025981013B001C"],
+      from: [nameMatch, udidMatch]
+    )
+
+    XCTAssertTrue(match === udidMatch)
+  }
+
+  func testCaptureDeviceDoesNotSelectCameraOrNonMuxedIOSDevice() {
+    let continuityCamera = CaptureDeviceStub(
+      uniqueID: "18FF4BAB-BBC5-497B-90FF-466300000001",
+      localizedName: "Test iPhone",
+      modelID: "iPhone17,2",
+      mediaTypes: [.muxed]
+    )
+    let nonMuxedIOSDevice = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "Test iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.video]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: ["00008140-00025981013B001C"],
+      from: [continuityCamera, nonMuxedIOSDevice]
+    )
+
+    XCTAssertNil(match)
+  }
+
+  func testCaptureDeviceFallsBackToOnlyIOSScreenForOnlyConnectedDevice() {
+    let screenCapture = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "A Renamed iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: ["00008140-00025981013B001C"],
+      from: [screenCapture]
+    )
+
+    XCTAssertTrue(match === screenCapture)
+  }
+
+  func testCaptureDeviceDoesNotSelectAmbiguousExactNameMatches() {
+    let firstScreenCapture = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "Test iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+    let secondScreenCapture = CaptureDeviceStub(
+      uniqueID: "FC4D130B-105D-4AE4-B3C1-E7CBE0A68B27",
+      localizedName: "Test iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: ["00008140-00025981013B001C"],
+      from: [firstScreenCapture, secondScreenCapture]
+    )
+
+    XCTAssertNil(match)
+  }
+
+  func testCaptureDeviceDoesNotUseSingletonFallbackWithMultipleConnectedDevices() {
+    let screenCapture = CaptureDeviceStub(
+      uniqueID: "6E4B7E85-5A71-4E2A-AE7A-9A019929F435",
+      localizedName: "A Renamed iPhone",
+      modelID: "iOS Device",
+      mediaTypes: [.muxed]
+    )
+
+    let match = FBDeviceVideo.captureDevice(
+      forUDID: "00008140-00025981013B001C",
+      named: "Test iPhone",
+      connectedDeviceUDIDs: [
+        "00008140-00025981013B001C",
+        "00008140-00025981013B001D",
+      ],
+      from: [screenCapture]
+    )
+
+    XCTAssertNil(match)
   }
 }

--- a/FBDeviceControlTests/Tests/Unit/FBDeviceVideoTests.swift
+++ b/FBDeviceControlTests/Tests/Unit/FBDeviceVideoTests.swift
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import AVFoundation
+import FBControlCore
+@testable import FBDeviceControl
+import XCTest
+
+final class FBDeviceVideoTests: XCTestCase {
+  private final class AuthorizationStub {
+    var status: AVAuthorizationStatus
+    let statusAfterRequest: AVAuthorizationStatus?
+    let granted: Bool
+    var requestCount = 0
+
+    init(
+      status: AVAuthorizationStatus,
+      statusAfterRequest: AVAuthorizationStatus? = nil,
+      granted: Bool = false
+    ) {
+      self.status = status
+      self.statusAfterRequest = statusAfterRequest
+      self.granted = granted
+    }
+
+    func authorizationStatus() -> AVAuthorizationStatus {
+      status
+    }
+
+    func requestAccess() async -> Bool {
+      requestCount += 1
+      if let statusAfterRequest {
+        status = statusAfterRequest
+      }
+      return granted
+    }
+  }
+
+  private enum UnexpectedCaptureError: Error {
+    case captureDeviceLookup
+  }
+
+  private func logger(_ logger: CapturingLogger, contains substring: String) -> Bool {
+    for case let message as String in logger.messages {
+      if message.contains(substring) {
+        return true
+      }
+    }
+    return false
+  }
+
+  private func runAuthorization(
+    _ authorization: AuthorizationStub,
+    logger: CapturingLogger
+  ) async throws {
+    try await FBDeviceVideo.ensureVideoCaptureAuthorization(
+      logger: logger,
+      authorizationStatus: {
+        authorization.authorizationStatus()
+      },
+      requestAccess: {
+        await authorization.requestAccess()
+      }
+    )
+  }
+
+  private func authorizationError(
+    _ authorization: AuthorizationStub,
+    logger: CapturingLogger
+  ) async -> NSError? {
+    do {
+      try await runAuthorization(authorization, logger: logger)
+      XCTFail("Expected camera authorization to fail")
+      return nil
+    } catch {
+      return error as NSError
+    }
+  }
+
+  func testAuthorizedStatusSucceedsWithoutRequest() async throws {
+    let authorization = AuthorizationStub(status: .authorized)
+    let logger = CapturingLogger()
+
+    try await runAuthorization(authorization, logger: logger)
+
+    XCTAssertEqual(authorization.requestCount, 0)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status: authorized"))
+  }
+
+  func testDeniedStatusFailsWithoutRequest() async {
+    let authorization = AuthorizationStub(status: .denied)
+    let logger = CapturingLogger()
+
+    let error = await authorizationError(authorization, logger: logger)
+
+    XCTAssertEqual(error?.domain, FBDeviceControlErrorDomain)
+    XCTAssertTrue(error?.localizedDescription.contains("Camera authorization is denied") == true)
+    XCTAssertEqual(authorization.requestCount, 0)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status: denied"))
+  }
+
+  func testRestrictedStatusFailsWithoutRequest() async {
+    let authorization = AuthorizationStub(status: .restricted)
+    let logger = CapturingLogger()
+
+    let error = await authorizationError(authorization, logger: logger)
+
+    XCTAssertEqual(error?.domain, FBDeviceControlErrorDomain)
+    XCTAssertTrue(error?.localizedDescription.contains("Camera authorization is restricted") == true)
+    XCTAssertEqual(authorization.requestCount, 0)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status: restricted"))
+  }
+
+  func testNotDeterminedRequestsAccessAndSucceedsWhenAuthorized() async throws {
+    let authorization = AuthorizationStub(
+      status: .notDetermined,
+      statusAfterRequest: .authorized,
+      granted: true
+    )
+    let logger = CapturingLogger()
+
+    try await runAuthorization(authorization, logger: logger)
+
+    XCTAssertEqual(authorization.requestCount, 1)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status: notDetermined"))
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status after request: authorized (granted=YES)"))
+  }
+
+  func testNotDeterminedRequestsAccessAndFailsWhenDenied() async {
+    let authorization = AuthorizationStub(
+      status: .notDetermined,
+      statusAfterRequest: .denied,
+      granted: false
+    )
+    let logger = CapturingLogger()
+
+    let error = await authorizationError(authorization, logger: logger)
+
+    XCTAssertEqual(error?.domain, FBDeviceControlErrorDomain)
+    XCTAssertTrue(error?.localizedDescription.contains("Camera authorization is denied") == true)
+    XCTAssertEqual(authorization.requestCount, 1)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status after request: denied (granted=NO)"))
+  }
+
+  func testUnknownStatusFailsWithoutRequest() async throws {
+    let unknown = try XCTUnwrap(AVAuthorizationStatus(rawValue: Int.max))
+    let authorization = AuthorizationStub(status: unknown)
+    let logger = CapturingLogger()
+
+    let error = await authorizationError(authorization, logger: logger)
+
+    XCTAssertEqual(error?.domain, FBDeviceControlErrorDomain)
+    XCTAssertTrue(error?.localizedDescription.contains("unknown") == true)
+    XCTAssertEqual(authorization.requestCount, 0)
+    XCTAssertTrue(self.logger(logger, contains: "Camera authorization status: unknown"))
+  }
+
+  func testDeniedAuthorizationStopsBeforeScreenCaptureAndDeviceDiscovery() async {
+    let authorization = AuthorizationStub(status: .denied)
+    let logger = CapturingLogger()
+    var allowScreenCaptureCount = 0
+    var findCaptureDeviceCount = 0
+
+    do {
+      _ = try await FBDeviceVideo.captureSessionAsync(
+        logger: logger,
+        authorizationStatus: {
+          authorization.authorizationStatus()
+        },
+        requestAccess: {
+          await authorization.requestAccess()
+        },
+        allowAccessToScreenCaptureDevices: {
+          allowScreenCaptureCount += 1
+        },
+        findCaptureDevice: {
+          findCaptureDeviceCount += 1
+          throw UnexpectedCaptureError.captureDeviceLookup
+        }
+      )
+      XCTFail("Expected denied camera authorization to stop capture setup")
+    } catch {
+      let nsError = error as NSError
+      XCTAssertEqual(nsError.domain, FBDeviceControlErrorDomain)
+    }
+
+    XCTAssertEqual(allowScreenCaptureCount, 0)
+    XCTAssertEqual(findCaptureDeviceCount, 0)
+  }
+}

--- a/build.sh
+++ b/build.sh
@@ -309,6 +309,7 @@ function verify_companion_camera_usage_description() {
   local arch
   local info
   local description
+  local continuity_camera_device_type
 
   if [ ! -f "$binary" ]; then
     echo "error: idb_companion binary not found at $binary"
@@ -316,6 +317,14 @@ function verify_companion_camera_usage_description() {
   fi
   if ! expected=$(plutil -extract NSCameraUsageDescription raw -o - Companion/Info.plist); then
     echo "error: Companion/Info.plist has no readable NSCameraUsageDescription"
+    return 1
+  fi
+  if ! continuity_camera_device_type=$(plutil -extract NSCameraUseContinuityCameraDeviceType raw -o - Companion/Info.plist); then
+    echo "error: Companion/Info.plist has no readable NSCameraUseContinuityCameraDeviceType"
+    return 1
+  fi
+  if [[ "$continuity_camera_device_type" != "true" ]]; then
+    echo "error: Companion/Info.plist must set NSCameraUseContinuityCameraDeviceType to true"
     return 1
   fi
   if ! archs=$(lipo -archs "$binary") || [ -z "$archs" ]; then
@@ -337,7 +346,15 @@ function verify_companion_camera_usage_description() {
       echo "error: $binary ($arch) has unexpected NSCameraUsageDescription: $description"
       return 1
     fi
-    echo "Verified camera usage description in $binary ($arch)"
+    if ! continuity_camera_device_type=$(printf '%s\n' "$info" | sed -n '/^<?xml /,$p' | plutil -extract NSCameraUseContinuityCameraDeviceType raw -o - -); then
+      echo "error: $binary ($arch) has no readable NSCameraUseContinuityCameraDeviceType"
+      return 1
+    fi
+    if [[ "$continuity_camera_device_type" != "true" ]]; then
+      echo "error: $binary ($arch) must set NSCameraUseContinuityCameraDeviceType to true"
+      return 1
+    fi
+    echo "Verified camera privacy keys in $binary ($arch)"
   done
 }
 

--- a/build.sh
+++ b/build.sh
@@ -300,6 +300,47 @@ function strip_embedded_frameworks() {
   strip_framework "XCTestBootstrap.framework/Versions/Current/Frameworks/FBControlCore.framework"
 }
 
+# Verify that the command-line companion carries the privacy usage description
+# in every Mach-O slice. INFOPLIST_FILE alone does not embed a plist in a tool.
+function verify_companion_camera_usage_description() {
+  local binary="$1"
+  local expected
+  local archs
+  local arch
+  local info
+  local description
+
+  if [ ! -f "$binary" ]; then
+    echo "error: idb_companion binary not found at $binary"
+    return 1
+  fi
+  if ! expected=$(plutil -extract NSCameraUsageDescription raw -o - Companion/Info.plist); then
+    echo "error: Companion/Info.plist has no readable NSCameraUsageDescription"
+    return 1
+  fi
+  if ! archs=$(lipo -archs "$binary") || [ -z "$archs" ]; then
+    echo "error: Could not determine architectures for $binary"
+    return 1
+  fi
+
+  for arch in $archs; do
+    info=$(otool -arch "$arch" -P "$binary")
+    if [[ "$info" != *"(__TEXT,__info_plist) section"* ]]; then
+      echo "error: $binary ($arch) is missing __TEXT,__info_plist"
+      return 1
+    fi
+    if ! description=$(printf '%s\n' "$info" | sed -n '/^<?xml /,$p' | plutil -extract NSCameraUsageDescription raw -o - -); then
+      echo "error: $binary ($arch) has no readable NSCameraUsageDescription"
+      return 1
+    fi
+    if [[ "$description" != "$expected" ]]; then
+      echo "error: $binary ($arch) has unexpected NSCameraUsageDescription: $description"
+      return 1
+    fi
+    echo "Verified camera usage description in $binary ($arch)"
+  done
+}
+
 # =============================================================================
 # Build Functions
 # =============================================================================
@@ -388,6 +429,7 @@ function build_idb_companion() {
     -derivedDataPath "$BUILD_DIRECTORY" \
     -configuration Release \
     build
+  verify_companion_camera_usage_description "$BUILD_DIRECTORY/Products/Release/idb_companion"
   strip_embedded_frameworks
 }
 
@@ -455,6 +497,7 @@ function build_distribution() {
   # Companion executable and the REPL CLI.
   cp "$release/idb_companion" "$dist/"
   cp "$release/idb-repl" "$dist/"
+  verify_companion_camera_usage_description "$dist/idb_companion"
 
   # SwiftPM resource bundles (Bundle.module resolves relative to Bundle.main).
   local bundle


### PR DESCRIPTION
## Motivation

Fixes #894.

Physical-device video recording can fail on macOS 26 Tahoe for two independent reasons:

1. `idb_companion` did not embed its processed Info.plist in the command-line Mach-O. As a result, TCC could not reliably read `NSCameraUsageDescription`, and camera authorization was neither explicitly requested nor clearly diagnosed.
2. Tahoe may expose the muxed iOS screen source with an `AVCaptureDevice.uniqueID` that differs from the device's hardware UDID. The previous `AVCaptureDevice(uniqueID: device.udid)` lookup therefore returned `nil` until the existing 10-second timeout expired.

These failures could surface as a missing camera permission prompt or an `MJPEG/H264/etc first-frame timeout` because no video reached the client.

## Changes

### Camera privacy and authorization

- Embed the companion's processed Info.plist into the command-line Mach-O with `CREATE_INFOPLIST_SECTION_IN_BINARY=YES`.
- Explicitly inspect and log the `.video` authorization state.
- Call `AVCaptureDevice.requestAccess(for: .video)` when authorization is `notDetermined`.
- Return actionable errors for `denied`, `restricted`, and unknown states.
- Verify that every produced Mach-O slice contains the expected camera privacy metadata.

### Tahoe capture-device discovery

- Declare `NSCameraUseContinuityCameraDeviceType` in the companion Info.plist.
- Keep direct UDID lookup as the fast path.
- Fall back to an availability-aware `AVCaptureDevice.DiscoverySession`:
  - macOS 14 and later: external and Continuity Camera devices
  - Earlier supported versions: external unknown devices
- Select only muxed devices whose model is `iOS Device`.
- Resolve transformed identifiers using the following ambiguity-safe order:
  1. Unique normalized UDID match
  2. Unique exact device-name match
  3. Single screen source when only one iOS device is connected
- Reject ambiguous matches instead of selecting an arbitrary source.
- Log capture-device inventory changes and successful matches.
- Preserve the existing 10-second discovery timeout.

## Test Plan

- `bash -n build.sh`
- Build `FBDeviceControl` successfully.
- Compile the Swift video test bundle.
- Run 7 camera-authorization tests and 6 capture-device resolution tests: 13 passed, 0 failed.
- Build `idb_companion`.
- Verify that the arm64 and x86_64 binaries contain:
  - `NSCameraUsageDescription`
  - `NSCameraUseContinuityCameraDeviceType = true`

The complete `FBDeviceControlTests` target remains blocked by a pre-existing issue on `main`: `FBAMDeviceTests.swift` cannot find `FBCreateZeroedAMDCalls`.