### PR TITLE
docs: update obsolete pip3.6 installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ A cli tool and python client is provided to interact with `idb`.
 It can be installed via pip:
 
 ```
-pip3.6 install fb-idb
+python3 -m pip install fb-idb
 ```
-Note: The idb client requires python 3.6 or greater to be installed.
+Note: The idb client requires Python 3.7 or greater to be installed.
 
 Please refer to [fbidb.io](https://www.fbidb.io/) for detailed installation instructions and a guided tour of idb.
 

--- a/website/docs/idb/installation.mdx
+++ b/website/docs/idb/installation.mdx
@@ -31,10 +31,10 @@ A cli tool and python client is provided to interact with idb.
 It can be installed via pip:
 
 ```
-pip3.6 install fb-idb
+python3 -m pip install fb-idb
 ```
 
-Note: The idb client requires python 3.6 or greater to be installed.
+Note: The idb client requires Python 3.7 or greater to be installed.
 
 Note: Instructions on how to install pip can be found [here](https://pip.pypa.io/en/stable/installation/)
 


### PR DESCRIPTION
## Summary
Updates obsolete `pip3.6` installation commands across `README.md` and `website/docs/idb/installation.mdx` to the standard `python3 -m pip install fb-idb`.

Fixes #876

## Test Plan
Verified document formatting and rendered markdown.