### PR TITLE
Load SimulatorKit before the Indigo HID client lookup to avoid clientClassUnavailable

### DIFF
--- a/FBSimulatorControl/HID/FBSimulatorIndigoHIDClient.swift
+++ b/FBSimulatorControl/HID/FBSimulatorIndigoHIDClient.swift
@@ -50,6 +50,10 @@ final class FBSimulatorIndigoHIDClient: @unchecked Sendable {
 
   /// Looks up, allocates and initializes the runtime-only HID client for the provided device.
   convenience init(for device: SimDevice) throws {
+    // `objc_lookUpClass` returns nil until SimulatorKit is resident, so load it before the lookup
+    // instead of relying on an earlier caller — mirroring the sibling `FBSimulatorIndigoHID.init()`.
+    // The loader is `dispatch_once`-guarded, so this is a no-op when SimulatorKit is already loaded.
+    try FBSimulatorControlFrameworkLoader.xcodeFrameworks.loadPrivateFrameworks(nil)
     guard let clientClass = objc_lookUpClass(Self.clientClassName) else {
       throw FBSimulatorHIDError.clientClassUnavailable(className: Self.clientClassName)
     }


### PR DESCRIPTION
Fixes #941

## Motivation

As reported in #941, `FBSimulatorIndigoHIDTransport.indigo(for:)` builds its two failable arguments in declaration order, which Swift evaluates left-to-right: `FBSimulatorIndigoHIDClient(for:)` — which looks up the runtime-only SimulatorKit class `SimDeviceLegacyHIDClient` with `objc_lookUpClass` — is evaluated before the sibling `FBSimulatorIndigoHID()`, the only thing on this path that loads SimulatorKit (via `xcodeFrameworks.loadPrivateFrameworks()`). So the lookup runs before SimulatorKit is resident, and any process that hasn't already loaded it fails the entire Indigo path with `clientClassUnavailable`.

`idb_companion` doesn't hit this because `FBIDBCommandExecutor.connectToHID()` pre-loads `xcodeFrameworks` before connecting. It only surfaces for consumers that link `FBSimulatorControl` directly and follow the documented HID entry point — `FBSimulatorHID(for:)`, which on a simulator without an active `dtuhidd` selects the `.indigo` transport, so a plain `FBSimulatorHID(for: simulator)` fails. The sibling `FBSimulatorIndigoHID.init()` already loads SimulatorKit for its own `dlsym` needs; `FBSimulatorIndigoHIDClient` is the one class lookup on this path that relies on someone else having loaded it first.

## Test Plan

The fix loads SimulatorKit at the top of `FBSimulatorIndigoHIDClient.init(for:)`, before the lookup, so the type that needs the class is the one that guarantees the framework is resident — mirroring how the sibling `FBSimulatorIndigoHID.init()` already loads the framework it needs. The loader is `dispatch_once`/`hasLoadedFrameworks`-guarded, so it is a no-op wherever SimulatorKit is already loaded (all companion HID flows), leaving existing behavior unchanged. The fixes suggested in #941 — loading in `indigo(for:)`, or reordering the two arguments — are both sound and resolve the ordering directly; I went with loading inside the client's own initializer so that correctness stays independent of the factory's argument-evaluation order and lives next to the code that depends on it.

The `FBSimulatorControl` framework builds. The mechanism is confirmed by a standalone probe: `objc_lookUpClass("SimulatorKit.SimDeviceLegacyHIDClient")` returns nil before SimulatorKit is loaded (the exact condition that throws `clientClassUnavailable`) and resolves the class once it is `dlopen`-ed. The full end-to-end failure needs a direct `FBSimulatorControl` library consumer on a booted simulator with `dtuhidd` off, so it isn't covered by a unit test here; the fix is verified by inspection, by that probe, by the reproduction in #941, and by parity with the already-working companion preload.

## Related PRs

None.