### PR TITLE
Don't pass low-latency rate control to the JPEG encoder

### DIFF
--- a/FBSimulatorControl/Framebuffer/FBSimulatorVideoStreamFramePusher.swift
+++ b/FBSimulatorControl/Framebuffer/FBSimulatorVideoStreamFramePusher.swift
@@ -535,15 +535,26 @@ final class FBSimulatorVideoStreamFramePusher_VideoToolbox: FBSimulatorVideoStre
   }
 
   static func encoderSpecification(for format: FBVideoStreamFormat) -> [String: Any] {
-    if case .mjpeg(encoder: .allowSoftware) = format {
+    switch format {
+    case .mjpeg(encoder: .allowSoftware):
       return [
         kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder as String: true
       ]
+    case .mjpeg(encoder: .requireHardware), .minicap:
+      // Low-latency rate control is a video-codec selector. Passing it to the
+      // JPEG encoder makes VTCompressionSessionCreate return kVTParameterErr
+      // (-12902) on macOS 26.
+      return [
+        kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder as String: true
+      ]
+    case .compressedVideo:
+      return [
+        kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder as String: true,
+        kVTVideoEncoderSpecification_EnableLowLatencyRateControl as String: true,
+      ]
+    case .bgra:
+      return [:]
     }
-    return [
-      kVTVideoEncoderSpecification_RequireHardwareAcceleratedVideoEncoder as String: true,
-      kVTVideoEncoderSpecification_EnableLowLatencyRateControl as String: true,
-    ]
   }
 
   func tearDown() throws {


### PR DESCRIPTION
## Summary

`FBSimulatorVideoStreamFramePusher_VideoToolbox.encoderSpecification(for:)` returns
`RequireHardwareAcceleratedVideoEncoder` **plus** `EnableLowLatencyRateControl` for every
format except `.mjpeg(encoder: .allowSoftware)`.

`EnableLowLatencyRateControl` selects the low-latency **video** rate controller. The JPEG
encoder does not accept it, so on macOS 26 `VTCompressionSessionCreate` fails with
`kVTParameterErr` (-12902) and `setup(with:edgeInsets:)` throws
`failedToStartCompressionSession` before a single frame is encoded. Every
`idb video-stream --format mjpeg` and `--format minicap` is therefore dead on macOS 26,
while `--format h264` on the same machine works.

Related: #894, #829. #897 proposes an adjacent change, but against `FBSimulatorVideoStream.m`,
which no longer exists after the Swift rewrite; it also drops the hardware-encoder requirement
altogether, which is not necessary — the rate-control selector alone is what JPEG rejects.

## Fix

Make the mapping exhaustive over `FBVideoStreamFormat` rather than falling through to
"everything else":

- `.mjpeg(encoder: .requireHardware)` and `.minicap` (both JPEG) keep requiring a hardware
  encoder, without the rate-control selector;
- `.mjpeg(encoder: .allowSoftware)` is unchanged;
- `.compressedVideo` keeps both properties — H.264/HEVC behavior is byte-for-byte unchanged;
- `.bgra` returns an empty specification; it takes the bitmap pusher and never creates a
  compression session, so this case is inert and only exists to make the switch exhaustive.

Because the switch is exhaustive, a future format cannot silently inherit the H.264
specification the way the old trailing `return` allowed.

## Test plan

macOS 26 / Xcode 26, arm64, iPhone simulator:

- `idb video-stream --format mjpeg` — before: `VTCompressionSessionCreate` -12902, stream never
  starts; after: session is created and JPEG frames flow.
- `idb video-stream --format minicap` — same before/after.
- `idb video-stream --format h264` and `--format bgra` — unchanged.

This change has been carried in a locally patched companion build (idb v1.5.1 + this diff),
driving a continuous MJPEG framebuffer stream in day-to-day use since 2026-08.
